### PR TITLE
address a few ddc analysis items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.6
+
+* Fix two analysis issues with DDC's strong mode.
+
 ## 2.1.5
 
 * Fix a bug with 2.1.4 where source span information was being discarded for

--- a/lib/src/loader.dart
+++ b/lib/src/loader.dart
@@ -63,7 +63,7 @@ class Loader {
   YamlDocument _loadDocument(DocumentStartEvent firstEvent) {
     var contents = _loadNode(_parser.parse());
 
-    var lastEvent = _parser.parse();
+    var lastEvent = _parser.parse() as DocumentEndEvent;
     assert(lastEvent.type == EventType.DOCUMENT_END);
 
     return new YamlDocument.internal(

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -115,7 +115,7 @@ class Parser {
   ///
   ///     stream ::=
   ///       STREAM-START implicit_document? explicit_document* STREAM-END
-  ///       ************  
+  ///       ************
   Event _parseStreamStart() {
     var token = _scanner.scan();
     assert(token.type == TokenType.STREAM_START);
@@ -183,7 +183,7 @@ class Parser {
   ///
   ///     explicit_document    ::=
   ///       DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-  ///                                 ***********  
+  ///                                 ***********
   Event _parseDocumentContent() {
     var token = _scanner.peek();
 
@@ -462,7 +462,7 @@ class Parser {
   ///
   ///                              (VALUE block_node_or_indentless_sequence?)?)*
   ///                               ***** *
-  ///                              BLOCK-END  
+  ///                              BLOCK-END
   ///
   Event _parseBlockMappingValue() {
     var token = _scanner.peek();
@@ -527,7 +527,7 @@ class Parser {
     _scanner.scan();
     _state = _states.removeLast();
     return new Event(EventType.SEQUENCE_END, token.span);
-  }  
+  }
 
   /// Parses the productions:
   ///
@@ -670,7 +670,7 @@ class Parser {
     var token = _scanner.peek();
 
     var versionDirective;
-    var tagDirectives = [];
+    var tagDirectives = <TagDirective>[];
     while (token.type == TokenType.VERSION_DIRECTIVE ||
            token.type == TokenType.TAG_DIRECTIVE) {
       if (token is VersionDirectiveToken) {
@@ -699,7 +699,7 @@ class Parser {
 
       token = _scanner.advance();
     }
-    
+
     _appendTagDirective(
         new TagDirective("!", "!"),
         token.span.start.pointSpan(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml
-version: 2.1.5
+version: 2.1.6
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/yaml
 description: A parser for YAML.


### PR DESCRIPTION
Address two DDC analysis items:

```
The getter 'isImplicit' is not defined for the class 'Event'
(lib/src/loader.dart, line 75, col 32)

Type check failed: new Pair(versionDirective, tagDirectives) (Pair<dynamic, dynamic>) is not of type Pair<VersionDirective, List<TagDirective>> because tagDirectives cannot be typed as List<TagDirective>
(lib/src/parser.dart, line 712, col 12)
```

On one, we're referencing a field `isImplicit` on `Event` that the compiler can't prove is a `DocumentEndEvent`. On the other, we add an additional type parameter.