### PR TITLE
Do not try to fetch more tokens if the stream end is encountered.

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -324,6 +324,9 @@ class Scanner {
       if (_tokens.isNotEmpty) {
         _staleSimpleKeys();
 
+        // If there are no more tokens to fetch, break.
+        if (_tokens.last.type == TokenType.STREAM_END) break;
+
         // If the current token could be a simple key, we need to scan more
         // tokens until we determine whether it is or not. Otherwise we might
         // not emit the `KEY` token before we emit the value of the key.

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -30,8 +30,8 @@ main() {
   });
 
   group("refuses", () {
+    // Regression test for #19.
     test("invalid contents", () {
-      // This caused the scanner to hang in an infinite loop.
       expectYamlFails("{");
     });
 

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -29,7 +29,7 @@ main() {
     });
   });
 
-  group("refuses ", () {
+  group("refuses", () {
     test("invalid contents", () {
       // This caused the scanner to hang in an infinite loop.
       expectYamlFails("{");

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -43,18 +43,19 @@ main() {
          """);
       });
 
-    test("1.3", () {
-      expectYamlFails("""
-         %YAML 1.3
-         --- text
-         """);
-    });
+      test("1.3", () {
+        expectYamlFails("""
+           %YAML 1.3
+           --- text
+           """);
+      });
 
-    test("2.0", () {
-      expectYamlFails("""
-         %YAML 2.0
-         --- text
-         """);
+      test("2.0", () {
+        expectYamlFails("""
+           %YAML 2.0
+           --- text
+           """);
+      });
     });
   });
 

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -29,13 +29,19 @@ main() {
     });
   });
 
-  group("refuses documents that declare version", () {
-    test("1.0", () {
-      expectYamlFails("""
+  group("refuses ", () {
+    test("invalid contents", () {
+      // This caused the scanner to hang in an infinite loop.
+      expectYamlFails("{");
+    });
+
+    group("documents that declare version", () {
+      test("1.0", () {
+        expectYamlFails("""
          %YAML 1.0
          --- text
          """);
-    });
+      });
 
     test("1.3", () {
       expectYamlFails("""


### PR DESCRIPTION
The yaml scanner hung in an infinite loop when trying to scan this string: "{" (a single opening brace).

_fetchMoreTokens kept growing the token list with a STREAM_END token ad infinitum.