### PR TITLE
Add loadYamlFromFile method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ main() {
 }
 ```
 
+You can also use `loadYamlFromFile` to load a yaml file directly as a map.
+```dart
+import 'package:yaml/yaml.dart';
+
+main() {
+  var doc = loadYamlFromFile("./my_yaml");
+  print(doc['YAML']);
+}
+```
+
 This library currently doesn't support dumping to YAML. You should use
 `JSON.encode` from `dart:convert` instead:
 

--- a/lib/yaml.dart
+++ b/lib/yaml.dart
@@ -7,6 +7,7 @@ import 'src/style.dart';
 import 'src/yaml_document.dart';
 import 'src/yaml_exception.dart';
 import 'src/yaml_node.dart';
+import 'dart:io';
 
 export 'src/style.dart';
 export 'src/utils.dart' show YamlWarningCallback, yamlWarningCallback;
@@ -40,6 +41,11 @@ loadYaml(String yaml, {sourceUrl}) =>
 /// to be confident that the return value will always be a [YamlNode].
 YamlNode loadYamlNode(String yaml, {sourceUrl}) =>
     loadYamlDocument(yaml, sourceUrl: sourceUrl).contents;
+
+Map loadYamlFromFile(String yamlFilePath, {sourceUrl}) {
+  var yamlDocument = new File(yamlFilePath);
+  return loadYaml(yamlDocument.readAsStringSync());
+}
 
 /// Loads a single document from a YAML string as a [YamlDocument].
 ///

--- a/test/test_yaml.yaml
+++ b/test/test_yaml.yaml
@@ -1,0 +1,1 @@
+test: test

--- a/test/yaml_node_wrapper_test.dart
+++ b/test/yaml_node_wrapper_test.dart
@@ -5,6 +5,7 @@
 import 'package:source_span/source_span.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
+import 'dart:io';
 
 main() {
   test("YamlMap() with no sourceUrl", () {
@@ -13,6 +14,7 @@ main() {
     expect(map.nodes, isEmpty);
     expect(map.span, isNullSpan(isNull));
   });
+
 
   test("YamlMap() with a sourceUrl", () {
     var map = new YamlMap(sourceUrl: "source");
@@ -145,6 +147,12 @@ main() {
     expect(list[1] == list[1], isTrue);
     expect(list[1].nodes == list[1].nodes, isTrue);
     expect(list[1] == new YamlMap.wrap({"foo": "bar"}), isFalse);
+  });
+
+  test('LoadYamlFromDocument() thingy works', () {
+    var map = loadYamlFromFile("test/test_yaml.yaml");
+    expect(map, isNotNull);
+    expect(map, isNotEmpty);
   });
 }
 


### PR DESCRIPTION
My personal, primary use case for this library was to load a database configuration yaml into my code.  It was confusing to me that `loadYaml` and `loadYamlDocument` as I understand them, took a sort of string literal representation of a yaml file.  I suppose I expected one of these methods to behave like the one I've implemented here, where you point it to a yaml file, and are given a map or map-like object.  I think it might be nice to provide this abstraction in a method like `loadYamlFromFile` that behaves in such a way. 

I'm new to Dart, so if there are technical reasons to reject this PR, please let me know so I might make adjustments.  Otherwise, if it doesn't align with your goals for the library, thanks for at least taking the time to look at it :)  