### PR TITLE
Replace deprecated (now removed) JSON with json from dart:convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ main() {
 ```
 
 This library currently doesn't support dumping to YAML. You should use
-`JSON.encode` from `dart:convert` instead:
+`json.encode` from `dart:convert` instead:
 
 ```dart
 import 'dart:convert';
@@ -23,6 +23,6 @@ import 'package:yaml/yaml.dart';
 
 main() {
   var doc = loadYaml("YAML: YAML Ain't Markup Language");
-  print(JSON.encode(doc));
+  print(json.encode(doc));
 }
 ```


### PR DESCRIPTION
The `JsonCodec` `JSON` from `dart:convert` has been a deprecated alias for the `json` variable and is now removed.

https://github.com/dart-lang/sdk/commit/f2402b3c08b849062707ec06e6f43abb182e2196
https://github.com/dart-lang/sdk/blob/master/sdk/lib/convert/json.dart
