### PR TITLE
Add YamlNode.asJsonType()

### DIFF
--- a/lib/src/yaml_node_wrapper.dart
+++ b/lib/src/yaml_node_wrapper.dart
@@ -41,6 +41,10 @@ class YamlMapWrapper extends MapBase
     return value;
   }
 
+  @override
+  Map<String, dynamic> asJsonType() =>
+      Map<String, dynamic>.from(_dartMap.cast<String, dynamic>());
+
   int get hashCode => _dartMap.hashCode;
 
   operator ==(Object other) =>
@@ -110,6 +114,9 @@ class YamlListWrapper extends ListBase implements YamlList {
   operator []=(int index, value) {
     throw UnsupportedError("Cannot modify an unmodifiable List.");
   }
+
+  @override
+  List<dynamic> asJsonType() => List<dynamic>.from(_dartList);
 
   int get hashCode => _dartList.hashCode;
 


### PR DESCRIPTION
This will support use cases like the following:

```dart
@JsonSerializable()
class MyClass {
  ...
}

void main() {
  YamlMap yamlMap = loadYaml(content);
  MyClass obj = MyClass.fromJson(yamlMap.asJsonType());
}
```