### PR TITLE
Preserve parsed key order in maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+* BREAKING CHANGE: Make `YamlMap` preserve parsed key order.
+  This is breaking because some programs may rely on the
+  `HashMap` sort order.
+
 ## 2.1.16
 
 * Fixed deprecated API usage in README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.0
 
-* BREAKING CHANGE: Make `YamlMap` preserve parsed key order.
+* POSSIBLY BREAKING CHANGE: Make `YamlMap` preserve parsed key order.
   This is breaking because some programs may rely on the
   `HashMap` sort order.
 

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -10,7 +10,7 @@ import 'yaml_node.dart';
 
 /// Returns a [Map] that compares its keys based on [deepEquals].
 Map<K, V> deepEqualsMap<K, V>() =>
-    HashMap(equals: deepEquals, hashCode: deepHashCode);
+    LinkedHashMap(equals: deepEquals, hashCode: deepHashCode);
 
 /// Returns whether two objects are structurally equivalent.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml
-version: 2.1.16
+version: 2.2.0
 
 description: A parser for YAML, a human-friendly data serialization standard
 author: Dart Team <misc@dartlang.org>

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -1806,4 +1806,30 @@ main() {
         Also floats: [ .inf, -.Inf, +.INF, .NAN ]''');
     });
   });
+
+  test('preserves key order', () {
+    const keys = ['a', 'b', 'c', 'd', 'e', 'f'];
+    int sanityCheckCount = 0;
+    for (List<String> permutation in _generatePermutations(keys)) {
+      final yaml = permutation.map((key) => '$key: value').join('\n');
+      expect(loadYaml(yaml).keys.toList(), permutation);
+      sanityCheckCount++;
+    }
+    final expectedPermutationCount = List.generate(keys.length, (i) => i + 1).reduce((n, i) => n * i);
+    expect(sanityCheckCount, expectedPermutationCount);
+  });
+}
+
+Iterable<List<String>> _generatePermutations(List<String> keys) sync* {
+  if (keys.length <= 1) {
+    yield keys;
+    return;
+  }
+  for (int i = 0; i < keys.length; i++) {
+    final first = keys[i];
+    final rest = <String>[]..addAll(keys.sublist(0, i))..addAll(keys.sublist(i + 1));
+    for (List<String> subPermutation in _generatePermutations(rest)) {
+      yield <String>[first]..addAll(subPermutation);
+    }
+  }
 }

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -1815,7 +1815,8 @@ main() {
       expect(loadYaml(yaml).keys.toList(), permutation);
       sanityCheckCount++;
     }
-    final expectedPermutationCount = List.generate(keys.length, (i) => i + 1).reduce((n, i) => n * i);
+    final expectedPermutationCount =
+        List.generate(keys.length, (i) => i + 1).reduce((n, i) => n * i);
     expect(sanityCheckCount, expectedPermutationCount);
   });
 }
@@ -1827,7 +1828,9 @@ Iterable<List<String>> _generatePermutations(List<String> keys) sync* {
   }
   for (int i = 0; i < keys.length; i++) {
     final first = keys[i];
-    final rest = <String>[]..addAll(keys.sublist(0, i))..addAll(keys.sublist(i + 1));
+    final rest = <String>[]
+      ..addAll(keys.sublist(0, i))
+      ..addAll(keys.sublist(i + 1));
     for (List<String> subPermutation in _generatePermutations(rest)) {
       yield <String>[first]..addAll(subPermutation);
     }


### PR DESCRIPTION
Preserve parsed key order in `YamlMap`.

Fixes #55 
