### PR TITLE
[doc] Add an example.dart file

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+void main() {
+  var doc = loadYaml("YAML: YAML Ain't Markup Language");
+  print(doc['YAML']);
+}


### PR DESCRIPTION
Pana suggests to add an example.dart file
here: https://pub.dev/packages/yaml#-analysis-tab-

Closes https://github.com/dart-lang/yaml/issues/45