### PR TITLE
Add YAML-styled Serialization for YamlNode Family

### DIFF
--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -88,6 +88,11 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
 
   @override
   dynamic operator [](key) => nodes[key]?.value;
+
+  @override
+  String toString() {
+    return '';
+  }
 }
 
 // TODO(nweiz): Use UnmodifiableListMixin when issue 18970 is fixed.
@@ -142,6 +147,11 @@ class YamlList extends YamlNode with collection.ListMixin {
   @override
   operator []=(int index, value) {
     throw UnsupportedError('Cannot modify an unmodifiable List');
+  }
+
+  @override
+  String toString() {
+    return '';
   }
 }
 

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -91,6 +91,19 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
 
   @override
   String toString() {
+    switch (style) {
+      case 'ANY':
+        print('ANY');
+        break;
+      case 'BLOCK':
+        print('BLOCK');
+        break;
+      case 'FLOW':
+        print('FLOW');
+        break;
+      default:
+        break;
+    }
     return '';
   }
 }
@@ -151,6 +164,19 @@ class YamlList extends YamlNode with collection.ListMixin {
 
   @override
   String toString() {
+    switch (style) {
+      case 'ANY':
+        print('ANY');
+        break;
+      case 'BLOCK':
+        print('BLOCK');
+        break;
+      case 'FLOW':
+        print('FLOW');
+        break;
+      default:
+        break;
+    }
     return '';
   }
 }

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -213,6 +213,28 @@ class YamlScalar extends YamlNode {
 
   @override
   String toString({int indent}) {
+    switch (style) {
+      case 'ANY':
+        print('ANY');
+        break;
+      case 'PLAIN':
+        print('PLAIN');
+        break;
+      case 'LITERAL':
+        print('LITERAL');
+        break;
+      case 'FOLDED':
+        print('FOLDED');
+        break;
+      case 'SINGLE_QUOTED':
+        print('SINGLE_QUOTED');
+        break;
+      case 'DOUBLE_QUOTED':
+        print('DOUBLE_QUOTED');
+        break;
+      default:
+        break;
+    }
     return value.toString();
   }
 }

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -90,7 +90,7 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   dynamic operator [](key) => nodes[key]?.value;
 
   @override
-  String toString({int indent}) {
+  String toString({int indentOverride, CollectionStyle styleOverride}) {
     switch (style) {
       case 'ANY':
         print('ANY');
@@ -163,7 +163,7 @@ class YamlList extends YamlNode with collection.ListMixin {
   }
 
   @override
-  String toString({int indent}) {
+  String toString({int indentOverride, CollectionStyle styleOverride}) {
     switch (style) {
       case 'ANY':
         print('ANY');
@@ -212,7 +212,7 @@ class YamlScalar extends YamlNode {
   }
 
   @override
-  String toString({int indent}) {
+  String toString({int indentOverride}) {
     switch (style) {
       case 'ANY':
         print('ANY');

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -116,19 +116,34 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
                     indentOverride:
                         (indentOverride != null) ? indentOverride : 0) +
                 ': ';
+            if (node.value is YamlList) {
+              result += '\n' +
+                  ((indentOverride != null)
+                      ? '  ' * (indentOverride + 1)
+                      : '  ');
+            } else if (node.value is YamlMap) {
+              result += '\n' +
+                  ((indentOverride != null)
+                      ? '  ' * (indentOverride + 1)
+                      : '  ');
+            }
           } else if (node.key is YamlList) {
             result += '? ' +
                 (node.key as YamlList).toStringShaped(
                     indentOverride:
                         (indentOverride != null) ? indentOverride + 1 : 1);
-            result += '\n:\n' +
+            result += '\n' +
+                ((indentOverride != null) ? '  ' * (indentOverride) : '') +
+                ':\n' +
                 ((indentOverride != null) ? '  ' * (indentOverride + 1) : '  ');
           } else if (node.key is YamlMap) {
             result += '? ' +
                 (node.key as YamlMap).toStringShaped(
                     indentOverride:
                         (indentOverride != null) ? indentOverride + 1 : 1);
-            result += '\n:\n' +
+            result += '\n' +
+                ((indentOverride != null) ? '  ' * (indentOverride) : '') +
+                ':\n' +
                 ((indentOverride != null) ? '  ' * (indentOverride + 1) : '  ');
           }
           result += node.value.toStringShaped(

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -97,6 +97,7 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
     return toStringShaped();
   }
 
+  @override
   String toStringShaped({int indentOverride, CollectionStyle styleOverride}) {
     var result = '';
     styleOverride ??= style;
@@ -105,8 +106,46 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
     }
     switch (styleOverride) {
       case CollectionStyle.BLOCK:
+        for (var node in nodes.entries) {
+          if (result.isNotEmpty) {
+            result +=
+                '\n' + ((indentOverride != null) ? '  ' * indentOverride : '');
+          }
+          if (node.key is YamlScalar) {
+            result += (node.key as YamlScalar).toStringShaped(
+                    indentOverride:
+                        (indentOverride != null) ? indentOverride : 0) +
+                ': ';
+          } else if (node.key is YamlList) {
+            result += '? ' +
+                (node.key as YamlList).toStringShaped(
+                    indentOverride:
+                        (indentOverride != null) ? indentOverride + 1 : 1);
+            result += '\n:\n' +
+                ((indentOverride != null) ? '  ' * (indentOverride + 1) : '  ');
+          } else if (node.key is YamlMap) {
+            result += '? ' +
+                (node.key as YamlMap).toStringShaped(
+                    indentOverride:
+                        (indentOverride != null) ? indentOverride + 1 : 1);
+            result += '\n:\n' +
+                ((indentOverride != null) ? '  ' * (indentOverride + 1) : '  ');
+          }
+          result += node.value.toStringShaped(
+              indentOverride:
+                  (indentOverride != null) ? indentOverride + 1 : 1);
+        }
         break;
       case CollectionStyle.FLOW:
+        result += '{' +
+            nodes.entries
+                .map((e) =>
+                    (e.key as YamlNode)
+                        .toStringShaped(styleOverride: CollectionStyle.FLOW) +
+                    ': ' +
+                    e.value.toStringShaped(styleOverride: CollectionStyle.FLOW))
+                .join(', ') +
+            '}';
         break;
       default:
         break;
@@ -174,6 +213,7 @@ class YamlList extends YamlNode with collection.ListMixin {
     return toStringShaped();
   }
 
+  @override
   String toStringShaped({int indentOverride, CollectionStyle styleOverride}) {
     var result = '';
     styleOverride ??= style;
@@ -252,6 +292,7 @@ class YamlScalar extends YamlNode {
     return toStringShaped();
   }
 
+  @override
   String toStringShaped({int indentOverride, CollectionStyle styleOverride}) {
     String result;
     switch (style) {
@@ -286,7 +327,7 @@ class YamlScalar extends YamlNode {
                 if (lines[line][i] == ' ') {
                   initialWhitespace++;
                 } else {
-        break;
+                  break;
                 }
               }
 
@@ -299,13 +340,13 @@ class YamlScalar extends YamlNode {
                   newLines.add(lines[line].substring(0, i));
                   lines[line] =
                       lines[line].substring(i + 1, lines[line].length);
-        break;
+                  break;
                 }
               }
 
               if (lines[line].length > lineLimit &&
                   !lines[line].substring(initialWhitespace).contains(' ')) {
-        break;
+                break;
               }
             }
             if (lines[line].isNotEmpty) {

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -90,7 +90,7 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   dynamic operator [](key) => nodes[key]?.value;
 
   @override
-  String toString() {
+  String toString({int indent}) {
     switch (style) {
       case 'ANY':
         print('ANY');
@@ -163,7 +163,7 @@ class YamlList extends YamlNode with collection.ListMixin {
   }
 
   @override
-  String toString() {
+  String toString({int indent}) {
     switch (style) {
       case 'ANY':
         print('ANY');
@@ -212,7 +212,9 @@ class YamlScalar extends YamlNode {
   }
 
   @override
-  String toString() => value.toString();
+  String toString({int indent}) {
+    return value.toString();
+  }
 }
 
 /// Sets the source span of a [YamlNode].

--- a/lib/src/yaml_node_wrapper.dart
+++ b/lib/src/yaml_node_wrapper.dart
@@ -53,6 +53,12 @@ class YamlMapWrapper extends MapBase
   @override
   bool operator ==(Object other) =>
       other is YamlMapWrapper && other._dartMap == _dartMap;
+
+  @override
+  String toStringShaped({int indentOverride, CollectionStyle styleOverride}) {
+    // TODO: implement toStringShaped
+    throw UnimplementedError();
+  }
 }
 
 /// The implementation of [YamlMapWrapper.nodes] as a wrapper around the Dart
@@ -137,6 +143,12 @@ class YamlListWrapper extends ListBase implements YamlList {
   @override
   bool operator ==(Object other) =>
       other is YamlListWrapper && other._dartList == _dartList;
+
+  @override
+  String toStringShaped({int indentOverride, CollectionStyle styleOverride}) {
+    // TODO: implement toStringShaped
+    throw UnimplementedError();
+  }
 }
 
 // TODO(nweiz): Use UnmodifiableListMixin when issue 18970 is fixed.


### PR DESCRIPTION
This pull request adds YAML-styled serialization support for YamlNode family, namely `YamlScalar`, `YamlList`, and `YamlMap`.

Serialization is opinionated; indentations are two-spaces per indentation level, and flow-styled nodes are single-line.

The implementation leaves out indentation on first lines for more straightforward concatenation logic and does not modify test logic because of inconsistent styling of YAML specification examples.