### PR TITLE
fix afterLineBreak value

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -779,7 +779,7 @@ class Scanner {
 
   /// Eats whitespace and comments until the next token is found.
   void _scanToNextToken() {
-    var afterLineBreak = false;
+    var afterLineBreak = _scanner.column == 0;
     while (true) {
       // Allow the BOM to start a line.
       if (_scanner.column == 0) _scanner.scan('\uFEFF');


### PR DESCRIPTION
The afterLineBreak starts with a value `false` instead it should also consider the column no of Scanner.