### PR TITLE
temporary fix for issue 51

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -1460,6 +1460,9 @@ class Scanner {
           buffer.write(whitespace);
           whitespace.clear();
         }
+      } else if (_scanner.peekChar() == RIGHT_CURLY) {
+        // If last entry with no "," indicator, break out and prevent updation of [end]
+        break;
       }
 
       // libyaml's notion of valid identifiers differs substantially from YAML

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -86,7 +86,7 @@ line 5, column 10: message
   });
 
   group('flow', () {
-    YamlMap yaml_n0, yaml_n1, yaml_n2, yaml_n3;
+    YamlMap yamlN0, yamlN1, yamlN2, yamlN3;
 
     setUpAll(() {
       const dtr = '''
@@ -109,14 +109,14 @@ line 5, column 10: message
         ,
   ''';
 
-      yaml_n0 = loadYaml(dtr) as YamlMap;
-      yaml_n1 = yaml_n0.nodes['nested_0'] as YamlMap;
-      yaml_n2 = yaml_n1.nodes['nested_1'] as YamlMap;
-      yaml_n3 = yaml_n2.nodes['nested_2'] as YamlMap;
+      yamlN0 = loadYaml(dtr) as YamlMap;
+      yamlN1 = yamlN0.nodes['nested_0'] as YamlMap;
+      yamlN2 = yamlN1.nodes['nested_1'] as YamlMap;
+      yamlN3 = yamlN2.nodes['nested_2'] as YamlMap;
     });
 
     test('root last key', () {
-      _expectSpan(yaml_n0.nodes['rk2'].span, r'''
+      _expectSpan(yamlN0.nodes['rk2'].span, r'''
 line 16, column 10: message
    ╷
 16 │     'rk2': 44
@@ -126,7 +126,7 @@ line 16, column 10: message
     });
 
     test('nested level 1 last key', () {
-      _expectSpan(yaml_n1.nodes['n0k2'].span, r'''
+      _expectSpan(yamlN1.nodes['n0k2'].span, r'''
 line 12, column 13: message
    ╷
 12 │       'n0k2': aval      
@@ -138,7 +138,7 @@ line 12, column 13: message
     });
 
     test('nested level 2 last key', () {
-      _expectSpan(yaml_n2.nodes['n1k2'].span, r'''
+      _expectSpan(yamlN2.nodes['n1k2'].span, r'''
 line 10, column 15: message
    ╷
 10 │       'n1k2': 425
@@ -147,7 +147,7 @@ line 10, column 15: message
     });
 
     test('nested level 3 first key', () {
-      _expectSpan(yaml_n3.nodes['n2k1'].span, r'''
+      _expectSpan(yamlN3.nodes['n2k1'].span, r'''
 line 4, column 17: message
   ╷
 4 │           'n2k1': null
@@ -158,7 +158,7 @@ line 4, column 17: message
     });
 
     test('nested level 3 mid key', () {
-      _expectSpan(yaml_n3.nodes['n2k2'].span, r'''
+      _expectSpan(yamlN3.nodes['n2k2'].span, r'''
 line 6, column 17: message
   ╷
 6 │           'n2k2': a
@@ -169,7 +169,7 @@ line 6, column 17: message
     });
 
     test('nested level 3 last key', () {
-      _expectSpan(yaml_n3.nodes['n2k3'].span, r'''
+      _expectSpan(yamlN3.nodes['n2k3'].span, r'''
 line 8, column 40: message
   ╷
 8 │         'n2k3':                        4     

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -165,4 +165,99 @@ line 8, column 3: message
   ╵''');
     });
   });
+
+  group('flow', () {
+    YamlMap yamlN0, yamlN1, yamlN2, yamlN3;
+
+    setUpAll(() {
+      const dtr = '''
+  'nested_0': {
+    'nested_1': {
+      'nested_2': {
+        'n2k1': null
+        ,
+        'n2k2': a
+        ,
+        'n2k3':                        4     
+      },
+      'n1k2': 425
+    },
+    'n0k2': aval      
+
+                      ,
+  }
+  'rk2': 44
+        ,
+  ''';
+
+    yamlN0 = loadYaml(dtr) as YamlMap;
+    yamlN1 = yamlN0.nodes['nested_0'] as YamlMap;
+    yamlN2 = yamlN1.nodes['nested_1'] as YamlMap;
+    yamlN3 = yamlN2.nodes['nested_2'] as YamlMap;
+  });
+
+    test('root last key', () {
+      _expectSpan(yamlN0.nodes['rk2'].span, r'''
+line 16, column 10: message
+   ╷
+16 │     'rk2': 44
+   │ ┌──────────^
+17 │ └         ,
+   ╵''');
+    });
+
+    test('nested level 1 last key', () {
+      _expectSpan(yamlN1.nodes['n0k2'].span, r'''
+line 12, column 13: message
+   ╷
+12 │       'n0k2': aval      
+   │ ┌─────────────^
+13 │ │ 
+14 │ │                       ,
+   │ └──────────────────────^
+   ╵''');
+    });
+
+//  TODO : Uncomment after resolving of issue #81
+// 
+//     test('nested level 2 last key', () {
+//       _expectSpan(yamlN2.nodes['n1k2'].span, r'''
+// line 10, column 15: message
+//    ╷
+// 10 │       'n1k2': 425
+//    │               ^^^
+//    ╵''');
+//     });
+
+    test('nested level 3 first key', () {
+      _expectSpan(yamlN3.nodes['n2k1'].span, r'''
+line 4, column 17: message
+  ╷
+4 │           'n2k1': null
+  │ ┌─────────────────^
+5 │ │         ,
+  │ └────────^
+  ╵''');
+    });
+
+    test('nested level 3 mid key', () {
+      _expectSpan(yamlN3.nodes['n2k2'].span, r'''
+line 6, column 17: message
+  ╷
+6 │           'n2k2': a
+  │ ┌─────────────────^
+7 │ │         ,
+  │ └────────^
+  ╵''');
+    });
+
+    test('nested level 3 last key', () {
+      _expectSpan(yamlN3.nodes['n2k3'].span, r'''
+line 8, column 40: message
+  ╷
+8 │         'n2k3':                        4     
+  │                                        ^
+  ╵''');
+    });
+  });
 }

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -16,7 +16,7 @@ void _expectSpan(SourceSpan source, String expected) {
 }
 
 void main() {
-  YamlMap yaml;
+  YamlMap yaml, yaml_n0, yaml_n1, yaml_n2, yaml_n3;
 
   setUpAll(() {
     yaml = loadYaml(const JsonEncoder.withIndent(' ').convert({
@@ -41,7 +41,7 @@ line 2, column 9: message
     );
   });
 
-  test('first root key', () {
+  test('last root key', () {
     _expectSpan(
       yaml.nodes['null'].span,
       r'''
@@ -60,7 +60,7 @@ line 7, column 10: message
       nestedMap = yaml.nodes['nested'] as YamlMap;
     });
 
-    test('first root key', () {
+    test('first nested key', () {
       _expectSpan(
         nestedMap.nodes['null'].span,
         r'''
@@ -72,18 +72,107 @@ line 4, column 11: message
       );
     });
 
-    test('first root key', () {
+    test('last nested key', () {
       _expectSpan(
         nestedMap.nodes['num'].span,
         r'''
 line 5, column 10: message
   ╷
-5 │     "num": 42
-  │ ┌──────────^
-6 │ │  },
-  │ └─^
+5 │   "num": 42
+  │          ^^
   ╵''',
       );
+    });
+  });
+
+  group('all nested', () {
+    setUpAll(() {
+      const dtr = '''
+  'nested_0': {
+    'nested_1': {
+      'nested_2': {
+        'n2k1': null
+        ,
+        'n2k2': a
+        ,
+        'n2k3':                        4     
+      },
+      'n1k2': 425
+    },
+    'n0k2': aval      
+
+                      ,
+  }
+  'rk2': 44
+        ,
+  ''';
+
+      yaml_n0 = loadYaml(dtr) as YamlMap;
+      yaml_n1 = yaml_n0.nodes['nested_0'] as YamlMap;
+      yaml_n2 = yaml_n1.nodes['nested_1'] as YamlMap;
+      yaml_n3 = yaml_n2.nodes['nested_2'] as YamlMap;
+    });
+
+    test('root last key', () {
+      _expectSpan(yaml_n0.nodes['rk2'].span, r'''
+line 16, column 10: message
+   ╷
+16 │     'rk2': 44
+   │ ┌──────────^
+17 │ └         ,
+   ╵''');
+    });
+
+    test('nested level 1 last key', () {
+      _expectSpan(yaml_n1.nodes['n0k2'].span, r'''
+line 12, column 13: message
+   ╷
+12 │       'n0k2': aval      
+   │ ┌─────────────^
+13 │ │ 
+14 │ │                       ,
+   │ └──────────────────────^
+   ╵''');
+    });
+
+    test('nested level 2 last key', () {
+      _expectSpan(yaml_n2.nodes['n1k2'].span, r'''
+line 10, column 15: message
+   ╷
+10 │       'n1k2': 425
+   │               ^^^
+   ╵''');
+    });
+
+    test('nested level 3 first key', () {
+      _expectSpan(yaml_n3.nodes['n2k1'].span, r'''
+line 4, column 17: message
+  ╷
+4 │           'n2k1': null
+  │ ┌─────────────────^
+5 │ │         ,
+  │ └────────^
+  ╵''');
+    });
+
+    test('nested level 3 mid key', () {
+      _expectSpan(yaml_n3.nodes['n2k2'].span, r'''
+line 6, column 17: message
+  ╷
+6 │           'n2k2': a
+  │ ┌─────────────────^
+7 │ │         ,
+  │ └────────^
+  ╵''');
+    });
+
+    test('nested level 3 last key', () {
+      _expectSpan(yaml_n3.nodes['n2k3'].span, r'''
+line 8, column 40: message
+  ╷
+8 │         'n2k3':                        4     
+  │                                        ^
+  ╵''');
     });
   });
 }

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -190,11 +190,11 @@ line 8, column 3: message
         ,
   ''';
 
-    yamlN0 = loadYaml(dtr) as YamlMap;
-    yamlN1 = yamlN0.nodes['nested_0'] as YamlMap;
-    yamlN2 = yamlN1.nodes['nested_1'] as YamlMap;
-    yamlN3 = yamlN2.nodes['nested_2'] as YamlMap;
-  });
+      yamlN0 = loadYaml(dtr) as YamlMap;
+      yamlN1 = yamlN0.nodes['nested_0'] as YamlMap;
+      yamlN2 = yamlN1.nodes['nested_1'] as YamlMap;
+      yamlN3 = yamlN2.nodes['nested_2'] as YamlMap;
+    });
 
     test('root last key', () {
       _expectSpan(yamlN0.nodes['rk2'].span, r'''
@@ -219,7 +219,7 @@ line 12, column 13: message
     });
 
 //  TODO : Uncomment after resolving of issue #81
-// 
+//
 //     test('nested level 2 last key', () {
 //       _expectSpan(yamlN2.nodes['n1k2'].span, r'''
 // line 10, column 15: message

--- a/test/span_test.dart
+++ b/test/span_test.dart
@@ -16,7 +16,7 @@ void _expectSpan(SourceSpan source, String expected) {
 }
 
 void main() {
-  YamlMap yaml, yaml_n0, yaml_n1, yaml_n2, yaml_n3;
+  YamlMap yaml;
 
   setUpAll(() {
     yaml = loadYaml(const JsonEncoder.withIndent(' ').convert({
@@ -85,7 +85,9 @@ line 5, column 10: message
     });
   });
 
-  group('all nested', () {
+  group('flow', () {
+    YamlMap yaml_n0, yaml_n1, yaml_n2, yaml_n3;
+
     setUpAll(() {
       const dtr = '''
   'nested_0': {


### PR DESCRIPTION
Temporary fix for issue 51 (Spans for nested map renders needlessly multiline) and added tests for validation. Doesn't cause any unintended side effects for trailing spaces upto "," indicator, but needs more testing to validate for any special cases.