### PR TITLE
minor: Remove member from initializer list to constructor argument

### DIFF
--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -1658,8 +1658,7 @@ class _SimpleKey {
   final bool required;
 
   _SimpleKey(this.tokenNumber, this.line, this.column, this.location,
-      {bool required})
-      : required = required;
+      {this.required});
 }
 
 /// The ways to handle trailing whitespace for a block scalar.


### PR DESCRIPTION
Just curious as to why one syntax was chosen over the other? Personally, I feel the changes follow a consistent style.

> Sorry if this PR seems silly.