### PR TITLE
Preserving comments while parsing

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -152,6 +152,25 @@ class MappingStartEvent extends _ValueEvent {
   MappingStartEvent(this.span, this.style, {this.anchor, this.tag});
 }
 
+/// An event indicating a comment.
+class CommentEvent implements Event {
+  @override
+  EventType get type => EventType.comment;
+  @override
+  final FileSpan span;
+
+  /// The contents of the scalar.
+  final String value;
+
+  /// The style of the scalar in the original source.
+  final CommentStyle style;
+
+  CommentEvent(this.span, this.value, this.style);
+
+  @override
+  String toString() => '$type "$value"';
+}
+
 /// The types of [Event] objects.
 enum EventType {
   streamStart,
@@ -160,6 +179,7 @@ enum EventType {
   documentEnd,
   alias,
   scalar,
+  comment,
   sequenceStart,
   sequenceEnd,
   mappingStart,

--- a/lib/src/loader.dart
+++ b/lib/src/loader.dart
@@ -5,7 +5,6 @@
 import 'package:charcode/ascii.dart';
 import 'package:source_span/source_span.dart';
 
-import '../yaml.dart';
 import 'equality.dart';
 import 'event.dart';
 import 'parser.dart';
@@ -77,7 +76,6 @@ class Loader {
 
   /// Composes a node.
   YamlNode _loadNode(Event firstEvent) {
-    print(firstEvent);
     switch (firstEvent.type) {
       case EventType.alias:
         return _loadAlias(firstEvent as AliasEvent);
@@ -165,7 +163,7 @@ class Loader {
     var event = _parser.parse();
     while (event.type != EventType.mappingEnd) {
       YamlNode key, value;
-      if(event is CommentEvent){
+      if (event is CommentEvent) {
         key = _loadNode(event);
         value = key;
       } else {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -104,6 +104,8 @@ class Parser {
         return _parseFlowMappingValue();
       case _State.FLOW_MAPPING_EMPTY_VALUE:
         return _parseFlowMappingValue(empty: true);
+      case _State.COMMENT:
+        return _parseComment();
       default:
         throw 'Unreachable';
     }
@@ -439,6 +441,10 @@ class Parser {
       return Event(EventType.mappingEnd, token.span);
     }
 
+    if (token.type == TokenType.comment) {
+      return _parseComment();
+    }
+
     throw YamlException('Expected a key while parsing a block mapping.',
         token.span.start.pointSpan());
   }
@@ -648,6 +654,18 @@ class Parser {
     return _processEmptyScalar(token.span.start);
   }
 
+  /// Parses the productions:
+  /// 
+  /// # Comments
+  CommentEvent _parseComment() {
+    var token = _scanner.scan();
+    if(token is CommentToken){
+      return CommentEvent(token.span, token.comment, token.style);
+    }
+
+    throw 'Unreachable';
+  }
+
   /// Generate an empty scalar event.
   Event _processEmptyScalar(SourceLocation location) =>
       ScalarEvent(location.pointSpan() as FileSpan, '', ScalarStyle.PLAIN);
@@ -780,6 +798,9 @@ class _State {
 
   /// Expect an empty value of a flow mapping.
   static const FLOW_MAPPING_EMPTY_VALUE = _State('FLOW_MAPPING_EMPTY_VALUE');
+
+  /// Expect a comment
+  static const COMMENT = _State('COMMENT');
 
   /// Expect nothing.
   static const END = _State('END');

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -250,6 +250,11 @@ class Parser {
   Event _parseNode({bool block = false, bool indentlessSequence = false}) {
     var token = _scanner.peek();
 
+    if (token.type == TokenType.comment) {
+      _state = _states.removeLast();
+      return _parseComment();
+    }
+
     if (token is AliasToken) {
       _scanner.scan();
       _state = _states.removeLast();
@@ -367,6 +372,10 @@ class Parser {
       _scanner.scan();
       _state = _states.removeLast();
       return Event(EventType.sequenceEnd, token.span);
+    }
+
+    if (token is CommentToken) {
+      return _parseComment();
     }
 
     throw YamlException("While parsing a block collection, expected '-'.",
@@ -655,11 +664,11 @@ class Parser {
   }
 
   /// Parses the productions:
-  /// 
+  ///
   /// # Comments
   CommentEvent _parseComment() {
     var token = _scanner.scan();
-    if(token is CommentToken){
+    if (token is CommentToken) {
       return CommentEvent(token.span, token.comment, token.style);
     }
 

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -799,8 +799,10 @@ class Scanner {
             length: 1);
       }
 
-      // Eat a comment until a line break.
-      _skipComment();
+      // Scan comments
+      if (_scanner.peekChar() == HASH) {
+        _scanComment();
+      }
 
       // If we're at a line break, eat it.
       if (_isBreak) {
@@ -848,7 +850,7 @@ class Scanner {
 
     // Eat the rest of the line, including any comments.
     _skipBlanks();
-    _skipComment();
+    _scanComment();
 
     if (!_isBreakOrEnd) {
       throw YamlException('Expected comment or line break after directive.',
@@ -1125,7 +1127,7 @@ class Scanner {
 
     // Eat whitespace and comments to the end of the line.
     _skipBlanks();
-    _skipComment();
+    _scanComment();
 
     // Check if we're at the end of the line.
     if (!_isBreakOrEnd) {
@@ -1620,11 +1622,20 @@ class Scanner {
   }
 
   /// Moves the scanner past a comment, if one starts at the current position.
-  void _skipComment() {
-    if (_scanner.peekChar() != HASH) return;
+  Token _scanComment() {
+    var start = _scanner.state;
+    var ch = _scanner.peekChar();
+    var comment = '';
+
     while (!_isBreakOrEnd) {
-      _scanner.readChar();
+      ch = _scanner.readChar();
+      if(ch != null) {
+        comment += String.fromCharCode(ch);
+      }
     }
+
+    return CommentToken(_scanner.spanFrom(start), comment,
+      CommentStyle.INLINE);
   }
 }
 

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -1127,7 +1127,9 @@ class Scanner {
 
     // Eat whitespace and comments to the end of the line.
     _skipBlanks();
-    print(_scanComment());
+
+    // TODO: Handle _scanComment
+    _scanComment();
 
     // Check if we're at the end of the line.
     if (!_isBreakOrEnd) {
@@ -1629,13 +1631,12 @@ class Scanner {
 
     while (!_isBreakOrEnd) {
       ch = _scanner.readChar();
-      if(ch != null) {
+      if (ch != null) {
         comment += String.fromCharCode(ch);
       }
     }
 
-    return CommentToken(_scanner.spanFrom(start), comment,
-      CommentStyle.INLINE);
+    return CommentToken(_scanner.spanFrom(start), comment, CommentStyle.INLINE);
   }
 }
 

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -801,7 +801,7 @@ class Scanner {
 
       // Scan comments
       if (_scanner.peekChar() == HASH) {
-        _scanComment();
+        _tokens.add(_scanComment());
       }
 
       // If we're at a line break, eat it.
@@ -1127,7 +1127,7 @@ class Scanner {
 
     // Eat whitespace and comments to the end of the line.
     _skipBlanks();
-    _scanComment();
+    print(_scanComment());
 
     // Check if we're at the end of the line.
     if (!_isBreakOrEnd) {

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -70,3 +70,16 @@ class CollectionStyle {
   @override
   String toString() => name;
 }
+
+/// An enum of comment styles
+class CommentStyle {
+  static const SINGLE_LINE = CommentStyle._('SINGLE_LINE');
+  static const INLINE = CommentStyle._('INLINE');
+  static const KEY = CommentStyle._('KEY');
+
+  final String name;
+  const CommentStyle._(this.name);
+
+  @override
+  String toString() => name;
+}

--- a/lib/src/token.dart
+++ b/lib/src/token.dart
@@ -123,6 +123,25 @@ class ScalarToken implements Token {
   String toString() => 'SCALAR $style "$value"';
 }
 
+/// A comment token
+class CommentToken implements Token {
+  @override
+  TokenType get type => TokenType.comment;
+  @override
+  final FileSpan span;
+
+  /// Comment string
+  final String comment;
+
+  /// Style of the comment
+  final CommentStyle style;
+
+  CommentToken(this.span, this.comment, this.style);
+
+  @override
+  String toString() => 'Comment $style "$comment"';
+}
+
 /// The types of [Token] objects.
 enum TokenType {
   streamStart,
@@ -146,6 +165,7 @@ enum TokenType {
   flowEntry,
   key,
   value,
+  comment,
 
   alias,
   anchor,

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -57,7 +57,9 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   Map get value => this;
 
   @override
-  Iterable get keys => nodes.keys.map((node) => node.value).where((node) => !(node is YamlComment));
+  Iterable get keys => nodes.keys
+      .map((node) => node.value)
+      .where((node) => !(node is YamlComment));
 
   /// Creates an empty YamlMap.
   ///
@@ -89,11 +91,11 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   @override
   dynamic operator [](key) => nodes[key]?.value;
 
-  // @override
-  // String toString() {
-  //   var temp = Map.from(nodes)..removeWhere((k, v) => k is YamlComment);
-  //   return temp.toString();
-  // }
+  @override
+  String toString() {
+    var temp = Map.from(nodes)..removeWhere((k, v) => k is YamlComment);
+    return temp.toString();
+  }
 }
 
 // TODO(nweiz): Use UnmodifiableListMixin when issue 18970 is fixed.
@@ -149,6 +151,12 @@ class YamlList extends YamlNode with collection.ListMixin {
   operator []=(int index, value) {
     throw UnsupportedError('Cannot modify an unmodifiable List');
   }
+
+  @override
+  String toString() {
+    var temp = List.from(nodes)..removeWhere((item) => item is YamlComment);
+    return temp.toString();
+  }
 }
 
 /// A wrapped scalar value parsed from YAML.
@@ -197,7 +205,8 @@ class YamlComment extends YamlNode {
   }
 
   /// Users of the library should not use this constructor.
-  YamlComment.internal(this.value, CommentEvent comment) : style = CommentStyle.SINGLE_LINE {
+  YamlComment.internal(this.value, CommentEvent comment)
+      : style = CommentStyle.SINGLE_LINE {
     _span = comment.span;
   }
 

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -57,7 +57,7 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   Map get value => this;
 
   @override
-  Iterable get keys => nodes.keys.map((node) => node.value);
+  Iterable get keys => nodes.keys.map((node) => node.value).where((node) => !(node is YamlComment));
 
   /// Creates an empty YamlMap.
   ///
@@ -88,6 +88,12 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
 
   @override
   dynamic operator [](key) => nodes[key]?.value;
+
+  // @override
+  // String toString() {
+  //   var temp = Map.from(nodes)..removeWhere((k, v) => k is YamlComment);
+  //   return temp.toString();
+  // }
 }
 
 // TODO(nweiz): Use UnmodifiableListMixin when issue 18970 is fixed.
@@ -172,6 +178,32 @@ class YamlScalar extends YamlNode {
   /// Users of the library should not use this constructor.
   YamlScalar.internalWithSpan(this.value, SourceSpan span)
       : style = ScalarStyle.ANY {
+    _span = span;
+  }
+
+  @override
+  String toString() => value.toString();
+}
+
+/// A wrapped comment parsed from YAML.
+class YamlComment extends YamlNode {
+  @override
+  final String value;
+
+  final CommentStyle style;
+
+  YamlComment.wrap(this.value, {sourceUrl}) : style = CommentStyle.SINGLE_LINE {
+    _span = NullSpan(sourceUrl);
+  }
+
+  /// Users of the library should not use this constructor.
+  YamlComment.internal(this.value, CommentEvent comment) : style = CommentStyle.SINGLE_LINE {
+    _span = comment.span;
+  }
+
+  /// Users of the library should not use this constructor.
+  YamlComment.internalWithSpan(this.value, SourceSpan span)
+      : style = CommentStyle.SINGLE_LINE {
     _span = span;
   }
 

--- a/lib/src/yaml_node_wrapper.dart
+++ b/lib/src/yaml_node_wrapper.dart
@@ -42,6 +42,7 @@ class YamlMapWrapper extends MapBase
   @override
   dynamic operator [](Object key) {
     var value = _dartMap[key];
+    print(value);
     if (value is Map) return YamlMapWrapper._(value, span);
     if (value is List) return YamlListWrapper._(value, span);
     return value;


### PR DESCRIPTION
I made some updates to handle the following case successfully.

```yaml
name: yaml # comment
# another comment
# comment
tags:
  - parser # umm
  - dart
  - language
version: 2.2.1-dev # yet another comment
```
Opening a draft pull request to get feedback on whether I am using the preferred
way to preserve comments in the Yaml data structures.

It throws an error for cases when there is an immediate comment after key.
```yaml
tags: # umm
  - parser
  - dart
  - language
```

P.S. Comments are being tracked in `nodes` property of `YamlNode`; thus,
will get exposed to the user program if tried to access using `yamlMap.nodes`