### PR TITLE
Added style as an optional named parameter for wrap()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2-dev
+
+* Allow `YamlNode`s to be wrapped with an optional `style` parameter.
+
 ## 2.2.1
 
 * Update min Dart SDK to `2.4.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.2-dev
+## 2.3.0-dev
 
 * Allow `YamlNode`s to be wrapped with an optional `style` parameter.
 

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -163,6 +163,7 @@ class YamlScalar extends YamlNode {
   ///
   /// [sourceUrl] may be either a [String], a [Uri], or `null`.
   YamlScalar.wrap(this.value, {sourceUrl, this.style = ScalarStyle.ANY}) {
+    ArgumentError.checkNotNull(style, 'style');
     _span = NullSpan(sourceUrl);
   }
 

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -77,8 +77,9 @@ class YamlMap extends YamlNode with collection.MapMixin, UnmodifiableMapMixin {
   /// passed, it's used as the [SourceSpan.sourceUrl].
   ///
   /// [sourceUrl] may be either a [String], a [Uri], or `null`.
-  factory YamlMap.wrap(Map dartMap, {sourceUrl}) =>
-      YamlMapWrapper(dartMap, sourceUrl);
+  factory YamlMap.wrap(Map dartMap,
+          {sourceUrl, CollectionStyle style = CollectionStyle.ANY}) =>
+      YamlMapWrapper(dartMap, sourceUrl, style: style);
 
   /// Users of the library should not use this constructor.
   YamlMap.internal(Map<dynamic, YamlNode> nodes, SourceSpan span, this.style)
@@ -127,8 +128,9 @@ class YamlList extends YamlNode with collection.ListMixin {
   /// passed, it's used as the [SourceSpan.sourceUrl].
   ///
   /// [sourceUrl] may be either a [String], a [Uri], or `null`.
-  factory YamlList.wrap(List dartList, {sourceUrl}) =>
-      YamlListWrapper(dartList, sourceUrl);
+  factory YamlList.wrap(List dartList,
+          {sourceUrl, CollectionStyle style = CollectionStyle.ANY}) =>
+      YamlListWrapper(dartList, sourceUrl, style: style);
 
   /// Users of the library should not use this constructor.
   YamlList.internal(List<YamlNode> nodes, SourceSpan span, this.style)
@@ -160,7 +162,7 @@ class YamlScalar extends YamlNode {
   /// [sourceUrl] is passed, it's used as the [SourceSpan.sourceUrl].
   ///
   /// [sourceUrl] may be either a [String], a [Uri], or `null`.
-  YamlScalar.wrap(this.value, {sourceUrl}) : style = ScalarStyle.ANY {
+  YamlScalar.wrap(this.value, {sourceUrl, this.style = ScalarStyle.ANY}) {
     _span = NullSpan(sourceUrl);
   }
 

--- a/lib/src/yaml_node_wrapper.dart
+++ b/lib/src/yaml_node_wrapper.dart
@@ -36,10 +36,13 @@ class YamlMapWrapper extends MapBase
       {CollectionStyle style = CollectionStyle.ANY})
       : this._(dartMap, NullSpan(sourceUrl), style: style);
 
-  YamlMapWrapper._(Map dartMap, SourceSpan span, {this.style})
+  YamlMapWrapper._(Map dartMap, SourceSpan span,
+      {this.style = CollectionStyle.ANY})
       : _dartMap = dartMap,
         span = span,
-        nodes = _YamlMapNodes(dartMap, span);
+        nodes = _YamlMapNodes(dartMap, span) {
+    ArgumentError.checkNotNull(style, 'style');
+  }
 
   @override
   dynamic operator [](Object key) {
@@ -116,10 +119,13 @@ class YamlListWrapper extends ListBase implements YamlList {
       {CollectionStyle style = CollectionStyle.ANY})
       : this._(dartList, NullSpan(sourceUrl), style: style);
 
-  YamlListWrapper._(List dartList, SourceSpan span, {this.style})
+  YamlListWrapper._(List dartList, SourceSpan span,
+      {this.style = CollectionStyle.ANY})
       : _dartList = dartList,
         span = span,
-        nodes = _YamlListNodes(dartList, span);
+        nodes = _YamlListNodes(dartList, span) {
+    ArgumentError.checkNotNull(style, 'style');
+  }
 
   @override
   dynamic operator [](int index) {

--- a/lib/src/yaml_node_wrapper.dart
+++ b/lib/src/yaml_node_wrapper.dart
@@ -16,7 +16,7 @@ class YamlMapWrapper extends MapBase
     with pkg_collection.UnmodifiableMapMixin
     implements YamlMap {
   @override
-  final style = CollectionStyle.ANY;
+  final style;
 
   final Map _dartMap;
 
@@ -32,9 +32,11 @@ class YamlMapWrapper extends MapBase
   @override
   Iterable get keys => _dartMap.keys;
 
-  YamlMapWrapper(Map dartMap, sourceUrl) : this._(dartMap, NullSpan(sourceUrl));
+  YamlMapWrapper(Map dartMap, sourceUrl,
+      {CollectionStyle style = CollectionStyle.ANY})
+      : this._(dartMap, NullSpan(sourceUrl), style: style);
 
-  YamlMapWrapper._(Map dartMap, SourceSpan span)
+  YamlMapWrapper._(Map dartMap, SourceSpan span, {this.style})
       : _dartMap = dartMap,
         span = span,
         nodes = _YamlMapNodes(dartMap, span);
@@ -89,7 +91,7 @@ class _YamlMapNodes extends MapBase<dynamic, YamlNode>
 /// A wrapper that makes a normal Dart list behave like a [YamlList].
 class YamlListWrapper extends ListBase implements YamlList {
   @override
-  final style = CollectionStyle.ANY;
+  final style;
 
   final List _dartList;
 
@@ -110,10 +112,11 @@ class YamlListWrapper extends ListBase implements YamlList {
     throw UnsupportedError('Cannot modify an unmodifiable List.');
   }
 
-  YamlListWrapper(List dartList, sourceUrl)
-      : this._(dartList, NullSpan(sourceUrl));
+  YamlListWrapper(List dartList, sourceUrl,
+      {CollectionStyle style = CollectionStyle.ANY})
+      : this._(dartList, NullSpan(sourceUrl), style: style);
 
-  YamlListWrapper._(List dartList, SourceSpan span)
+  YamlListWrapper._(List dartList, SourceSpan span, {this.style})
       : _dartList = dartList,
         span = span,
         nodes = _YamlListNodes(dartList, span);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml
-version: 2.2.2-dev
+version: 2.3.0-dev
 
 description: A parser for YAML, a human-friendly data serialization standard
 homepage: https://github.com/dart-lang/yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: yaml
-version: 2.2.1
+version: 2.2.2-dev
 
 description: A parser for YAML, a human-friendly data serialization standard
 homepage: https://github.com/dart-lang/yaml
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
   charcode: ^1.1.0
-  collection: '>=1.1.0 <2.0.0'
-  string_scanner: '>=0.1.4 <2.0.0'
-  source_span: '>=1.0.0 <2.0.0'
+  collection: ">=1.1.0 <2.0.0"
+  string_scanner: ">=0.1.4 <2.0.0"
+  source_span: ">=1.0.0 <2.0.0"
 
 dev_dependencies:
   pedantic: ^1.0.0
-  path: '>=1.2.0 <2.0.0'
-  test: '>=0.12.0 <2.0.0'
+  path: ">=1.2.0 <2.0.0"
+  test: ">=0.12.0 <2.0.0"

--- a/test/yaml_node_wrapper_test.dart
+++ b/test/yaml_node_wrapper_test.dart
@@ -68,6 +68,10 @@ void main() {
     expect(map.nodes.keys, everyElement(TypeMatcher<YamlScalar>()));
     expect(map.nodes[YamlScalar.wrap('list')], equals([1, 2, 3]));
     expect(map.style, equals(CollectionStyle.ANY));
+    expect((map.nodes['list'] as YamlList).style, equals(CollectionStyle.ANY));
+    expect((map.nodes['map'] as YamlMap).style, equals(CollectionStyle.ANY));
+    expect((map['map'].nodes['nested'] as YamlList).style,
+        equals(CollectionStyle.ANY));
   });
 
   test('YamlMap.wrap() with a sourceUrl', () {
@@ -85,7 +89,6 @@ void main() {
     expect(map['list'].span, isNullSpan(source));
     expect(map['map'].span, isNullSpan(source));
     expect(map.nodes['scalar'].span, isNullSpan(source));
-    expect(map.style, equals(CollectionStyle.ANY));
   });
 
   test('YamlMap.wrap() with a sourceUrl and style', () {
@@ -99,6 +102,10 @@ void main() {
     }, sourceUrl: 'source', style: CollectionStyle.BLOCK);
 
     expect(map.style, equals(CollectionStyle.BLOCK));
+    expect((map.nodes['list'] as YamlList).style, equals(CollectionStyle.ANY));
+    expect((map.nodes['map'] as YamlMap).style, equals(CollectionStyle.ANY));
+    expect((map['map'].nodes['nested'] as YamlList).style,
+        equals(CollectionStyle.ANY));
   });
 
   test('YamlList.wrap() with no sourceUrl', () {
@@ -135,6 +142,9 @@ void main() {
     expect(list.nodes[2].span, isNullSpan(isNull));
     expect(list[2], 'value');
     expect(list.style, equals(CollectionStyle.ANY));
+    expect((list[0] as YamlList).style, equals(CollectionStyle.ANY));
+    expect((list[1] as YamlMap).style, equals(CollectionStyle.ANY));
+    expect((list[1]['nested'] as YamlList).style, equals(CollectionStyle.ANY));
   });
 
   test('YamlList.wrap() with a sourceUrl', () {
@@ -152,7 +162,6 @@ void main() {
     expect(list[0].span, isNullSpan(source));
     expect(list[1].span, isNullSpan(source));
     expect(list.nodes[2].span, isNullSpan(source));
-    expect(list.style, equals(CollectionStyle.ANY));
   });
 
   test('YamlList.wrap() with a sourceUrl and style', () {
@@ -166,6 +175,9 @@ void main() {
     ], sourceUrl: 'source', style: CollectionStyle.FLOW);
 
     expect(list.style, equals(CollectionStyle.FLOW));
+    expect((list[0] as YamlList).style, equals(CollectionStyle.ANY));
+    expect((list[1] as YamlMap).style, equals(CollectionStyle.ANY));
+    expect((list[1]['nested'] as YamlList).style, equals(CollectionStyle.ANY));
   });
 
   test('re-wrapped objects equal one another', () {

--- a/test/yaml_node_wrapper_test.dart
+++ b/test/yaml_node_wrapper_test.dart
@@ -67,6 +67,7 @@ void main() {
     expect(map.keys, unorderedEquals(['list', 'map', 'scalar']));
     expect(map.nodes.keys, everyElement(TypeMatcher<YamlScalar>()));
     expect(map.nodes[YamlScalar.wrap('list')], equals([1, 2, 3]));
+    expect(map.style, equals(CollectionStyle.ANY));
   });
 
   test('YamlMap.wrap() with a sourceUrl', () {
@@ -84,6 +85,20 @@ void main() {
     expect(map['list'].span, isNullSpan(source));
     expect(map['map'].span, isNullSpan(source));
     expect(map.nodes['scalar'].span, isNullSpan(source));
+    expect(map.style, equals(CollectionStyle.ANY));
+  });
+
+  test('YamlMap.wrap() with a sourceUrl and style', () {
+    var map = YamlMap.wrap({
+      'list': [1, 2, 3],
+      'map': {
+        'foo': 'bar',
+        'nested': [4, 5, 6]
+      },
+      'scalar': 'value'
+    }, sourceUrl: 'source', style: CollectionStyle.BLOCK);
+
+    expect(map.style, equals(CollectionStyle.BLOCK));
   });
 
   test('YamlList.wrap() with no sourceUrl', () {
@@ -119,6 +134,7 @@ void main() {
     expect(list.nodes[2].value, 'value');
     expect(list.nodes[2].span, isNullSpan(isNull));
     expect(list[2], 'value');
+    expect(list.style, equals(CollectionStyle.ANY));
   });
 
   test('YamlList.wrap() with a sourceUrl', () {
@@ -129,12 +145,27 @@ void main() {
         'nested': [4, 5, 6]
       },
       'value'
-    ]);
+    ], sourceUrl: 'source');
 
-    expect(list.span, isNullSpan(isNull));
-    expect(list[0].span, isNullSpan(isNull));
-    expect(list[1].span, isNullSpan(isNull));
-    expect(list.nodes[2].span, isNullSpan(isNull));
+    var source = Uri.parse('source');
+    expect(list.span, isNullSpan(source));
+    expect(list[0].span, isNullSpan(source));
+    expect(list[1].span, isNullSpan(source));
+    expect(list.nodes[2].span, isNullSpan(source));
+    expect(list.style, equals(CollectionStyle.ANY));
+  });
+
+  test('YamlList.wrap() with a sourceUrl and style', () {
+    var list = YamlList.wrap([
+      [1, 2, 3],
+      {
+        'foo': 'bar',
+        'nested': [4, 5, 6]
+      },
+      'value'
+    ], sourceUrl: 'source', style: CollectionStyle.FLOW);
+
+    expect(list.style, equals(CollectionStyle.FLOW));
   });
 
   test('re-wrapped objects equal one another', () {
@@ -149,6 +180,28 @@ void main() {
     expect(list[1] == list[1], isTrue);
     expect(list[1].nodes == list[1].nodes, isTrue);
     expect(list[1] == YamlMap.wrap({'foo': 'bar'}), isFalse);
+  });
+
+  test('YamlScalar.wrap() with no sourceUrl', () {
+    var scalar = YamlScalar.wrap('foo');
+
+    expect(scalar.span, isNullSpan(isNull));
+    expect(scalar.value, 'foo');
+    expect(scalar.style, equals(ScalarStyle.ANY));
+  });
+
+  test('YamlScalar.wrap() with sourceUrl', () {
+    var scalar = YamlScalar.wrap('foo', sourceUrl: 'source');
+
+    var source = Uri.parse('source');
+    expect(scalar.span, isNullSpan(source));
+  });
+
+  test('YamlScalar.wrap() with sourceUrl and style', () {
+    var scalar = YamlScalar.wrap('foo',
+        sourceUrl: 'source', style: ScalarStyle.DOUBLE_QUOTED);
+
+    expect(scalar.style, equals(ScalarStyle.DOUBLE_QUOTED));
   });
 }
 


### PR DESCRIPTION
This pull request now allows for an optional `style` named parameter to be passed into the respective `wrap` functions of the different `YamlNode` types.