### PR TITLE
Attempt to recover from invalid YAML

### DIFF
--- a/lib/src/error_listener.dart
+++ b/lib/src/error_listener.dart
@@ -1,0 +1,33 @@
+import 'package:source_span/source_span.dart';
+
+import 'yaml_exception.dart';
+
+/// A listener that is notified of [YamlError]s during scanning/parsing.
+abstract class ErrorListener {
+  /// This method is invoked when an [error] has been found in the YAML.
+  void onError(YamlError error);
+}
+
+/// An error found in the YAML.
+class YamlError {
+  /// A message describing the exception.
+  final String message;
+
+  /// The span associated with this exception.
+  final FileSpan span;
+
+  YamlError(this.message, this.span);
+}
+
+extension YamlErrorExtensions on YamlError {
+  /// Creates a [YamlException] from a [YamlError].
+  YamlException toException() => YamlException(message, span);
+}
+
+/// An [ErrorListener] that collects all errors into [errors].
+class ErrorCollector extends ErrorListener {
+  final List<YamlError> errors = [];
+
+  @override
+  void onError(YamlError error) => errors.add(error);
+}

--- a/lib/src/error_listener.dart
+++ b/lib/src/error_listener.dart
@@ -1,33 +1,15 @@
-import 'package:source_span/source_span.dart';
-
 import 'yaml_exception.dart';
 
 /// A listener that is notified of [YamlError]s during scanning/parsing.
 abstract class ErrorListener {
   /// This method is invoked when an [error] has been found in the YAML.
-  void onError(YamlError error);
-}
-
-/// An error found in the YAML.
-class YamlError {
-  /// A message describing the exception.
-  final String message;
-
-  /// The span associated with this exception.
-  final FileSpan span;
-
-  YamlError(this.message, this.span);
-}
-
-extension YamlErrorExtensions on YamlError {
-  /// Creates a [YamlException] from a [YamlError].
-  YamlException toException() => YamlException(message, span);
+  void onError(YamlException error);
 }
 
 /// An [ErrorListener] that collects all errors into [errors].
 class ErrorCollector extends ErrorListener {
-  final List<YamlError> errors = [];
+  final List<YamlException> errors = [];
 
   @override
-  void onError(YamlError error) => errors.add(error);
+  void onError(YamlException error) => errors.add(error);
 }

--- a/lib/src/error_listener.dart
+++ b/lib/src/error_listener.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'yaml_exception.dart';
 
 /// A listener that is notified of [YamlError]s during scanning/parsing.

--- a/lib/src/loader.dart
+++ b/lib/src/loader.dart
@@ -4,6 +4,7 @@
 
 import 'package:charcode/ascii.dart';
 import 'package:source_span/source_span.dart';
+import 'package:yaml/src/error_listener.dart';
 
 import 'equality.dart';
 import 'event.dart';
@@ -30,8 +31,10 @@ class Loader {
   FileSpan _span;
 
   /// Creates a loader that loads [source].
-  factory Loader(String source, {Uri? sourceUrl, bool recover = false}) {
-    var parser = Parser(source, sourceUrl: sourceUrl, recover: recover);
+  factory Loader(String source,
+      {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) {
+    var parser = Parser(source,
+        sourceUrl: sourceUrl, recover: recover, errorListener: errorListener);
     var event = parser.parse();
     assert(event.type == EventType.streamStart);
     return Loader._(parser, event.span);

--- a/lib/src/loader.dart
+++ b/lib/src/loader.dart
@@ -30,8 +30,8 @@ class Loader {
   FileSpan _span;
 
   /// Creates a loader that loads [source].
-  factory Loader(String source, {Uri? sourceUrl}) {
-    var parser = Parser(source, sourceUrl: sourceUrl);
+  factory Loader(String source, {Uri? sourceUrl, bool recover = false}) {
+    var parser = Parser(source, sourceUrl: sourceUrl, recover: recover);
     var event = parser.parse();
     assert(event.type == EventType.streamStart);
     return Loader._(parser, event.span);

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -35,8 +35,8 @@ class Parser {
   bool get isDone => _state == _State.END;
 
   /// Creates a parser that parses [source].
-  Parser(String source, {Uri? sourceUrl})
-      : _scanner = Scanner(source, sourceUrl: sourceUrl);
+  Parser(String source, {Uri? sourceUrl, bool recover = false})
+      : _scanner = Scanner(source, sourceUrl: sourceUrl, recover: recover);
 
   /// Consumes and returns the next event.
   Event parse() {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -36,9 +36,15 @@ class Parser {
   bool get isDone => _state == _State.END;
 
   /// Creates a parser that parses [source].
+  ///
+  /// If [recover] is true, will attempt to recover from parse errors and may return
+  /// invalid or synthetic nodes. If [errorListener] is also supplied, its onError
+  /// method will be called for each error recovered from. It is not valid to
+  /// provide [errorListener] if [recover] is false.
   Parser(String source,
       {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener})
-      : _scanner = Scanner(source,
+      : assert(recover || errorListener == null),
+        _scanner = Scanner(source,
             sourceUrl: sourceUrl,
             recover: recover,
             errorListener: errorListener);

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -4,6 +4,7 @@
 
 import 'package:source_span/source_span.dart';
 import 'package:string_scanner/string_scanner.dart';
+import 'package:yaml/src/error_listener.dart';
 
 import 'event.dart';
 import 'scanner.dart';
@@ -35,8 +36,12 @@ class Parser {
   bool get isDone => _state == _State.END;
 
   /// Creates a parser that parses [source].
-  Parser(String source, {Uri? sourceUrl, bool recover = false})
-      : _scanner = Scanner(source, sourceUrl: sourceUrl, recover: recover);
+  Parser(String source,
+      {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener})
+      : _scanner = Scanner(source,
+            sourceUrl: sourceUrl,
+            recover: recover,
+            errorListener: errorListener);
 
   /// Consumes and returns the next event.
   Event parse() {

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -496,13 +496,9 @@ class Scanner {
       if (key.line == _scanner.line) continue;
 
       if (key.required) {
-        final error = _reportError("Expected ':'.", _scanner.emptySpan);
-        if (_recover) {
-          _tokens.insert(key.tokenNumber - _tokensParsed,
-              Token(TokenType.key, key.location.pointSpan() as FileSpan));
-        } else {
-          throw error.toException();
-        }
+        _reportError(YamlException("Expected ':'.", _scanner.emptySpan));
+        _tokens.insert(key.tokenNumber - _tokensParsed,
+            Token(TokenType.key, key.location.pointSpan() as FileSpan));
       }
 
       _simpleKeys[i] = null;
@@ -1641,11 +1637,13 @@ class Scanner {
     }
   }
 
-  /// Reports an error to [_errorListener] and returns the [YamlError].
-  YamlError _reportError(String message, FileSpan span) {
-    final error = YamlError("Expected ':'.", _scanner.emptySpan);
-    _errorListener?.onError(error);
-    return error;
+  /// Reports a [YamlException] to [_errorListener] and if [_recover] is false,
+  /// throw the exception.
+  void _reportError(YamlException exception) {
+    _errorListener?.onError(exception);
+    if (!_recover) {
+      throw exception;
+    }
   }
 }
 

--- a/lib/src/scanner.dart
+++ b/lib/src/scanner.dart
@@ -1637,13 +1637,13 @@ class Scanner {
     }
   }
 
-  /// Reports a [YamlException] to [_errorListener] and if [_recover] is false,
-  /// throw the exception.
+  /// Reports a [YamlException] to [_errorListener] if [_recover] is true,
+  /// otherwise throws the exception.
   void _reportError(YamlException exception) {
-    _errorListener?.onError(exception);
     if (!_recover) {
       throw exception;
     }
+    _errorListener?.onError(exception);
   }
 }
 

--- a/lib/yaml.dart
+++ b/lib/yaml.dart
@@ -33,11 +33,9 @@ export 'src/yaml_node.dart' hide setSpan;
 /// originated for error reporting.
 ///
 /// If [recover] is true, will attempt to recover from parse errors and may return
-/// invalid or synthetic nodes.
-///
-/// If [errorListener] is supplied, its onError method will be called for each
-/// error. If [recover] is false, parsing will end early so only the first error
-/// may be emitted.
+/// invalid or synthetic nodes. If [errorListener] is also supplied, its onError
+/// method will be called for each error recovered from. It is not valid to
+/// provide [errorListener] if [recover] is false.
 dynamic loadYaml(String yaml,
         {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) =>
     loadYamlNode(yaml,

--- a/lib/yaml.dart
+++ b/lib/yaml.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'src/error_listener.dart';
 import 'src/loader.dart';
 import 'src/style.dart';
 import 'src/yaml_document.dart';
@@ -33,16 +34,30 @@ export 'src/yaml_node.dart' hide setSpan;
 ///
 /// If [recover] is true, will attempt to recover from parse errors and may return
 /// invalid or synthetic nodes.
-dynamic loadYaml(String yaml, {Uri? sourceUrl, bool recover = false}) =>
-    loadYamlNode(yaml, sourceUrl: sourceUrl, recover: recover).value;
+///
+/// If [errorListener] is supplied, its onError method will be called for each
+/// error. If [recover] is false, parsing will end early so only the first error
+/// may be emitted.
+dynamic loadYaml(String yaml,
+        {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) =>
+    loadYamlNode(yaml,
+            sourceUrl: sourceUrl,
+            recover: recover,
+            errorListener: errorListener)
+        .value;
 
 /// Loads a single document from a YAML string as a [YamlNode].
 ///
 /// This is just like [loadYaml], except that where [loadYaml] would return a
 /// normal Dart value this returns a [YamlNode] instead. This allows the caller
 /// to be confident that the return value will always be a [YamlNode].
-YamlNode loadYamlNode(String yaml, {Uri? sourceUrl, bool recover = false}) =>
-    loadYamlDocument(yaml, sourceUrl: sourceUrl, recover: recover).contents;
+YamlNode loadYamlNode(String yaml,
+        {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) =>
+    loadYamlDocument(yaml,
+            sourceUrl: sourceUrl,
+            recover: recover,
+            errorListener: errorListener)
+        .contents;
 
 /// Loads a single document from a YAML string as a [YamlDocument].
 ///
@@ -50,8 +65,9 @@ YamlNode loadYamlNode(String yaml, {Uri? sourceUrl, bool recover = false}) =>
 /// normal Dart value this returns a [YamlDocument] instead. This allows the
 /// caller to access document metadata.
 YamlDocument loadYamlDocument(String yaml,
-    {Uri? sourceUrl, bool recover = false}) {
-  var loader = Loader(yaml, sourceUrl: sourceUrl, recover: recover);
+    {Uri? sourceUrl, bool recover = false, ErrorListener? errorListener}) {
+  var loader = Loader(yaml,
+      sourceUrl: sourceUrl, recover: recover, errorListener: errorListener);
   var document = loader.load();
   if (document == null) {
     return YamlDocument.internal(YamlScalar.internalWithSpan(null, loader.span),

--- a/lib/yaml.dart
+++ b/lib/yaml.dart
@@ -30,24 +30,28 @@ export 'src/yaml_node.dart' hide setSpan;
 ///
 /// If [sourceUrl] is passed, it's used as the URL from which the YAML
 /// originated for error reporting.
-dynamic loadYaml(String yaml, {Uri? sourceUrl}) =>
-    loadYamlNode(yaml, sourceUrl: sourceUrl).value;
+///
+/// If [recover] is true, will attempt to recover from parse errors and may return
+/// invalid or synthetic nodes.
+dynamic loadYaml(String yaml, {Uri? sourceUrl, bool recover = false}) =>
+    loadYamlNode(yaml, sourceUrl: sourceUrl, recover: recover).value;
 
 /// Loads a single document from a YAML string as a [YamlNode].
 ///
 /// This is just like [loadYaml], except that where [loadYaml] would return a
 /// normal Dart value this returns a [YamlNode] instead. This allows the caller
 /// to be confident that the return value will always be a [YamlNode].
-YamlNode loadYamlNode(String yaml, {Uri? sourceUrl}) =>
-    loadYamlDocument(yaml, sourceUrl: sourceUrl).contents;
+YamlNode loadYamlNode(String yaml, {Uri? sourceUrl, bool recover = false}) =>
+    loadYamlDocument(yaml, sourceUrl: sourceUrl, recover: recover).contents;
 
 /// Loads a single document from a YAML string as a [YamlDocument].
 ///
 /// This is just like [loadYaml], except that where [loadYaml] would return a
 /// normal Dart value this returns a [YamlDocument] instead. This allows the
 /// caller to access document metadata.
-YamlDocument loadYamlDocument(String yaml, {Uri? sourceUrl}) {
-  var loader = Loader(yaml, sourceUrl: sourceUrl);
+YamlDocument loadYamlDocument(String yaml,
+    {Uri? sourceUrl, bool recover = false}) {
+  var loader = Loader(yaml, sourceUrl: sourceUrl, recover: recover);
   var document = loader.load();
   if (document == null) {
     return YamlDocument.internal(YamlScalar.internalWithSpan(null, loader.span),

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,6 +4,7 @@
 
 import 'package:test/test.dart';
 import 'package:yaml/src/equality.dart' as equality;
+import 'package:yaml/src/error_listener.dart' show YamlError;
 import 'package:yaml/yaml.dart';
 
 /// A matcher that validates that a closure or Future throws a [YamlException].
@@ -20,6 +21,13 @@ Map deepEqualsMap([Map? from]) {
   var map = equality.deepEqualsMap();
   if (from != null) map.addAll(from);
   return map;
+}
+
+/// Asserts that an error has the given message and starts at the given line/col.
+void expectErrorAtLineCol(YamlError error, String message, int line, int col) {
+  expect(error.message, equals(message));
+  expect(error.span.start.line, equals(line));
+  expect(error.span.start.column, equals(col));
 }
 
 /// Asserts that a string containing a single YAML document produces a given

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,7 +4,6 @@
 
 import 'package:test/test.dart';
 import 'package:yaml/src/equality.dart' as equality;
-import 'package:yaml/src/error_listener.dart' show YamlError;
 import 'package:yaml/yaml.dart';
 
 /// A matcher that validates that a closure or Future throws a [YamlException].
@@ -24,10 +23,11 @@ Map deepEqualsMap([Map? from]) {
 }
 
 /// Asserts that an error has the given message and starts at the given line/col.
-void expectErrorAtLineCol(YamlError error, String message, int line, int col) {
+void expectErrorAtLineCol(
+    YamlException error, String message, int line, int col) {
   expect(error.message, equals(message));
-  expect(error.span.start.line, equals(line));
-  expect(error.span.start.column, equals(col));
+  expect(error.span!.start.line, equals(line));
+  expect(error.span!.start.column, equals(col));
 }
 
 /// Asserts that a string containing a single YAML document produces a given

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -61,6 +61,69 @@ void main() {
     });
   });
 
+  group('recovers', () {
+    test('from incomplete leading keys', () {
+      final yaml = cleanUpLiteral(r'''
+        dependencies:
+          zero
+          one: any
+          ''');
+      var result = loadYaml(yaml, recover: true);
+      expect(
+          result,
+          deepEquals({
+            'dependencies': {
+              'zero': null,
+              'one': 'any',
+            }
+          }));
+      // Skipped because this case is not currently handled. If it's the first
+      // package without the colon, because the value is indented from the line
+      // above, the whole `zero\n     one` is treated as a scalar value.
+    }, skip: true);
+    test('from incomplete keys', () {
+      final yaml = cleanUpLiteral(r'''
+        dependencies:
+          one: any
+          two
+          three:
+          four
+          five:
+            1.2.3
+          six: 5.4.3
+          ''');
+      var result = loadYaml(yaml, recover: true);
+      expect(
+          result,
+          deepEquals({
+            'dependencies': {
+              'one': 'any',
+              'two': null,
+              'three': null,
+              'four': null,
+              'five': '1.2.3',
+              'six': '5.4.3',
+            }
+          }));
+    });
+    test('from incomplete trailing keys', () {
+      final yaml = cleanUpLiteral(r'''
+        dependencies:
+          six: 5.4.3
+          seven
+          ''');
+      var result = loadYaml(yaml, recover: true);
+      expect(
+          result,
+          deepEquals({
+            'dependencies': {
+              'six': '5.4.3',
+              'seven': null,
+            }
+          }));
+    });
+  });
+
   test('includes source span information', () {
     var yaml = loadYamlNode(r'''
 - foo:

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+import 'package:yaml/src/error_listener.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils.dart';
@@ -62,13 +63,18 @@ void main() {
   });
 
   group('recovers', () {
+    var collector = ErrorCollector();
+    setUp(() {
+      collector = ErrorCollector();
+    });
+
     test('from incomplete leading keys', () {
       final yaml = cleanUpLiteral(r'''
         dependencies:
           zero
           one: any
           ''');
-      var result = loadYaml(yaml, recover: true);
+      var result = loadYaml(yaml, recover: true, errorListener: collector);
       expect(
           result,
           deepEquals({
@@ -77,6 +83,10 @@ void main() {
               'one': 'any',
             }
           }));
+      expect(collector.errors.length, equals(1));
+      // These errors are reported at the start of the next token (after the
+      // whitespace/newlines).
+      expectErrorAtLineCol(collector.errors[0], "Expected ':'.", 2, 2);
       // Skipped because this case is not currently handled. If it's the first
       // package without the colon, because the value is indented from the line
       // above, the whole `zero\n     one` is treated as a scalar value.
@@ -92,7 +102,7 @@ void main() {
             1.2.3
           six: 5.4.3
           ''');
-      var result = loadYaml(yaml, recover: true);
+      var result = loadYaml(yaml, recover: true, errorListener: collector);
       expect(
           result,
           deepEquals({
@@ -105,6 +115,12 @@ void main() {
               'six': '5.4.3',
             }
           }));
+
+      expect(collector.errors.length, equals(2));
+      // These errors are reported at the start of the next token (after the
+      // whitespace/newlines).
+      expectErrorAtLineCol(collector.errors[0], "Expected ':'.", 3, 2);
+      expectErrorAtLineCol(collector.errors[1], "Expected ':'.", 5, 2);
     });
     test('from incomplete trailing keys', () {
       final yaml = cleanUpLiteral(r'''


### PR DESCRIPTION
This is progress towards #102. Initially it covers from the case where a `key: value` is expected but so far only part of the `key` has been typed. This would usually raise an error `"Expected ':'"`.

