### PR TITLE
Codec | Implement a codec version similar to json

### DIFF
--- a/benchmark/codec_benchmark.dart
+++ b/benchmark/codec_benchmark.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:yaml/yaml.dart';
+
+void main() {
+  var       iterations = 100000;
+  Stopwatch timer;
+  Duration  jsonTime, yamlTime;
+
+  // Warmup
+  for (var i = 0; i < iterations; i++) {
+    json.encode(test);
+    yaml.encode(test);
+  }
+
+  print('Test with $iterations iterations');
+
+  timer = Stopwatch()..start();
+
+  for (var i = 0; i < iterations; i++) {
+    json.encode(test);
+  }
+
+  jsonTime = timer.elapsed;
+
+  print('Json: $jsonTime');
+
+  timer = Stopwatch()..start();
+
+  for (var i = 0; i < iterations; i++) {
+    yaml.encode(test);
+  }
+
+  yamlTime = timer.elapsed;
+
+  print('Yaml: $yamlTime');
+
+}
+
+const Map test = {
+  'string' : 'Test text.',
+  'number' : 1337,
+  'bool'   : false,
+  'list'   : [1,2,3,4],
+  'map'    : {
+    'a' : 1,
+    'b' : 2,
+    'c' : 'text',
+    'd' : ['a', 'b', 'c']
+  }
+};

--- a/lib/src/codec/codec.dart
+++ b/lib/src/codec/codec.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'decoder.dart';
+import 'encoder.dart';
+
+class YamlCodec extends Codec<Object?, String> {
+  const YamlCodec();
+  
+  @override
+  dynamic decode(String source) => YamlDecoder().convert(source);
+
+  @override
+  String  encode(Object? obj)   => YamlEncoder().convert(obj);
+  
+  @override
+  YamlEncoder get encoder => const YamlEncoder();
+
+  @override
+  YamlDecoder get decoder => const YamlDecoder();
+}
+
+const YamlCodec yaml = YamlCodec();
+
+Object? yamlDecode(String input) => yaml.decode(input);
+String  yamlEncode(Object? obj)  => yaml.encode(obj);

--- a/lib/src/codec/decoder.dart
+++ b/lib/src/codec/decoder.dart
@@ -1,0 +1,28 @@
+
+import 'dart:convert';
+import 'package:yaml/yaml.dart';
+import 'codec.dart';
+
+class _YamlDecoderSink extends ChunkedConversionSink<String> {
+  final Sink<Object?> sink;
+
+  _YamlDecoderSink(this.sink);
+  
+  @override
+  void add(String source) => sink.add(yaml.decode(source));
+
+  @override
+  void close()            => sink.close();
+}
+
+class YamlDecoder extends Converter<String, Object?> {
+  const YamlDecoder();
+
+  @override
+  ChunkedConversionSink<String> startChunkedConversion(Sink<Object?> sink) {
+    return _YamlDecoderSink(sink);
+  }
+  
+  @override
+  Object? convert(String input) => loadYaml(input);
+}

--- a/lib/src/codec/encoder.dart
+++ b/lib/src/codec/encoder.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+import 'package:yaml/yaml.dart';
+import 'codec.dart';
+
+class _YamlEncoderSink extends ChunkedConversionSink<Object?> {
+  final Sink<String> sink;
+
+  _YamlEncoderSink(this.sink);
+  
+  @override
+  void add(Object? obj) => sink.add(yaml.encode(obj));
+
+  @override
+  void close()          => sink.close();
+}
+
+class YamlEncoder extends Converter<Object?, String> {
+  const YamlEncoder();
+  
+  @override
+  ChunkedConversionSink<Object?> startChunkedConversion(Sink<String> sink) {
+    return _YamlEncoderSink(sink);
+  }
+  
+  @override
+  String convert(Object? obj) {
+    final buffer = StringBuffer('---\n');
+
+    if (_convertable(obj)) {
+      _objectToBuffer(obj, buffer);
+    }
+
+    return buffer.toString();
+  }
+
+  bool _convertable(Object? obj) => obj is List || obj is Map;
+
+  void _objectToBuffer(dynamic obj, StringBuffer buffer, [int indent = 0]) {
+    var p = ' ' * indent;
+    
+    if (obj is List) {
+
+      for (dynamic v in obj) {
+        buffer.write('$p-');
+
+        if (_convertable(v)) {
+          buffer.write('\n');
+        } else if (v is String && v.contains('\n')) {
+          buffer.write(' | \n');
+        }
+
+        _objectToBuffer(v, buffer, indent + 2);
+
+      }
+
+    } else if (obj is Map) {
+
+      for (var k in obj.keys) {
+        buffer.write('$p$k:');
+
+        if (_convertable(obj[k])) {
+          buffer.write('\n');
+        } else if (obj[k] is String && (obj[k] as String).contains('\n')) {
+          buffer.write(' | \n');
+        }
+
+        _objectToBuffer(obj[k], buffer, indent + 2);
+      }
+
+    } else if (obj == double.infinity) {
+      buffer.writeln(' .inf');
+    } else if (obj == -double.infinity) {
+      buffer.writeln(' -.inf');
+    } else {
+      
+      if (obj == null || obj is num || obj is bool) {
+        buffer.writeln(' $obj');
+      } else {
+
+        if (obj is String && obj.contains('\n')) {
+          buffer.writeln('$obj');
+        } else {
+          buffer.writeln(' \'$obj\'');
+        }     
+      }
+    }
+  }
+}

--- a/lib/yaml.dart
+++ b/lib/yaml.dart
@@ -14,6 +14,7 @@ export 'src/utils.dart' show YamlWarningCallback, yamlWarningCallback;
 export 'src/yaml_document.dart';
 export 'src/yaml_exception.dart';
 export 'src/yaml_node.dart' hide setSpan;
+export 'src/codec/codec.dart';
 
 /// Loads a single document from a YAML string.
 ///

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -1,0 +1,218 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  
+  test('YamlCodec can encode test data', () {
+    expect(yaml.encode(testData).trim(), testOutput.trim());
+  });
+
+  test('YamlCodec can decode test data', () {
+    var decoded = yaml.decode(testOutput);
+    
+    expect(decoded,                isMap);
+    expect(decoded.entries.length, testData.entries.length);
+  });
+  
+  test('YamlCodec can encode list', () {
+    expect(yaml.encode([1,2]).trim(), testList.trim());
+  });
+
+  test('YamlCodec can decode list', () {
+    expect(yaml.decode(testList), isList);
+  });
+  
+  test('YamlCodec can encode streams', () async {
+    var tests = await testEncodeStream.transform(yaml.encoder).toList();
+
+    expect(tests.length, 3);
+
+    expect(tests[0].trim(), testOutput.trim());
+    expect(tests[1].trim(), testOutput.trim());
+    expect(tests[2].trim(), testOutput.trim());
+  });
+
+  test('YamlCodec can decode streams', () async {
+    var tests = await testDecodeStream.transform(yaml.decoder).toList();
+
+    expect(tests.length, 3);
+
+    expect(tests[0], isMap); 
+    expect((tests[0] as Map).entries.length, testData.entries.length);
+
+    expect(tests[1], isMap);
+    expect((tests[1] as Map).entries.length, testData.entries.length);
+
+    expect(tests[2], isMap);
+    expect((tests[1] as Map).entries.length, testData.entries.length);
+  });
+
+}
+
+Stream<String> get testDecodeStream async * {
+  var i = 3;
+
+  while (i-- > 0) {
+    yield testOutput;
+    await Future.delayed(Duration(milliseconds: 25));
+  }
+}
+
+Stream<Object?> get testEncodeStream async * {
+  var i = 3;
+
+  while (i-- > 0) {
+    yield testData;
+    await Future.delayed(Duration(milliseconds: 25));
+  }
+}
+
+const String testList = '''
+---
+- 1
+- 2
+''';
+
+const String testOutput = '''
+---
+string: 'One liner'
+text: | 
+  Some text:
+  More or less
+  multi line!
+
+number: 0.0
+bool: false
+list:
+  - 'a'
+  - 'b'
+map:
+  a: 1
+  b: 2
+map-c:
+  a:
+    text: 'text'
+    number: 0.0
+    bool: false
+    list:
+      - 'a'
+      - 'b'
+    map:
+      a: 1
+      b: 2
+  b:
+    text: 'text'
+    number: 0.0
+    bool: false
+    list:
+      - 'a'
+      - 'b'
+    map:
+      a: 1
+      b: 2
+list-c:
+  -
+    text: 'text'
+    number: 0.0
+    bool: false
+    list:
+      - 'a'
+      - 'b'
+    map:
+      a: 1
+      b: 2
+  -
+    text: 'text'
+    number: 0.0
+    bool: false
+    list:
+      - 'a'
+      - 'b'
+    map:
+      a: 1
+      b: 2
+  - | 
+      Some text:
+      More or less
+      multi line!
+''';
+
+
+const Map testData = {
+  'string' : 'One liner',
+  'text'   : '''
+  Some text:
+  More or less
+  multi line!
+''',
+  'number' : 0.0,
+  'bool'   : false,
+  'list'   : [
+    'a', 'b'
+  ],
+  'map' : {
+    'a' : 1,
+    'b' : 2
+  },
+  'map-c' : {
+    'a' : {
+      'text': 'text',
+      'number' : 0.0,
+      'bool'   : false,
+      'list'   : [
+        'a', 'b'
+      ],
+      'map' : {
+        'a' : 1,
+        'b' : 2
+      }
+    },
+    'b' : {
+      'text': 'text',
+      'number' : 0.0,
+      'bool'   : false,
+      'list'   : [
+        'a', 'b'
+      ],
+      'map' : {
+        'a' : 1,
+        'b' : 2
+      }
+    }
+  },
+  'list-c'   : [
+    {
+      'text': 'text',
+      'number' : 0.0,
+      'bool'   : false,
+      'list'   : [
+        'a', 'b'
+      ],
+      'map' : {
+        'a' : 1,
+        'b' : 2
+      }
+    },
+    {
+      'text': 'text',
+      'number' : 0.0,
+      'bool'   : false,
+      'list'   : [
+        'a', 'b'
+      ],
+      'map' : {
+        'a' : 1,
+        'b' : 2
+      }
+    },
+    '''
+      Some text:
+      More or less
+      multi line!
+    '''
+  ],
+};


### PR DESCRIPTION
We also were in demand of writing yaml (config) files.

This first commit is trying to implement a version that is similar to the json codec.

See `test/codec_test.dart` for references.

Fixes #113 

Example usage:  
```dart

const Map test = {
  'string' : 'Test text.',
  'number' : 1337,
  'bool'   : false,
  'list'   : [1,2,3,4],
  'map'    : {
    'a' : 1,
    'b' : 2,
    'c' : 'text',
    'd' : ['a', 'b', 'c']
  }
};

print(yaml.encode(test));

/* Output:
---
string: 'Test text.'
number: 1337
bool: false
list:
  - 1
  - 2
  - 3
  - 4
map:
  a: 1
  b: 2
  c: 'text'
  d:
    - 'a'
    - 'b'
    - 'c'
*/
```