### PR TITLE
prep for publishing 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.1
+
+* Switch to using package:lints.
+* Populate the pubspec `repository` field.
+
 ## 3.1.0
 
 * `loadYaml` and related functions now accept a `recover` flag instructing the parser

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+[![Build Status](https://github.com/dart-lang/yaml/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/yaml/actions?query=workflow%3A"Dart+CI"+branch%3Amaster)
+[![Pub Package](https://img.shields.io/pub/v/yaml.svg)](https://pub.dev/packages/yaml)
+[![package publisher](https://img.shields.io/pub/publisher/yaml.svg)](https://pub.dev/packages/yaml/publisher)
+
 A parser for [YAML](https://yaml.org/).
 
-[![Pub Package](https://img.shields.io/pub/v/yaml.svg)](https://pub.dev/packages/yaml)
-[![Build Status](https://github.com/dart-lang/yaml/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/yaml/actions?query=workflow%3A"Dart+CI"+branch%3Amaster)
+## Usage
 
 Use `loadYaml` to load a single document, or `loadYamlStream` to load a
 stream of documents. For example:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,9 @@
 include: package:lints/recommended.yaml
+
 analyzer:
   strong-mode:
     implicit-casts: false
+
 linter:
   rules:
     - avoid_catching_errors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml
-version: 3.1.1-dev
+version: 3.1.1
 description: A parser for YAML, a human-friendly data serialization standard
 repository: https://github.com/dart-lang/yaml
 


### PR DESCRIPTION
prep for publishing 3.1.1:
- rev to 3.1.1
- update the changelog
- some tweaks to the markdown badges in the readme
