### PR TITLE
revert updating the type for YamlScalar.value

### DIFF
--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -103,7 +103,7 @@ class _DeepEquals {
 int deepHashCode(Object? obj) {
   var parents = [];
 
-  int deepHashCodeInner(value) {
+  int deepHashCodeInner(Object? value) {
     if (parents.any((parent) => identical(parent, value))) return -1;
 
     parents.add(value);
@@ -115,7 +115,7 @@ int deepHashCode(Object? obj) {
       } else if (value is Iterable) {
         return const IterableEquality().hash(value.map(deepHashCode));
       } else if (value is YamlScalar) {
-        return value.value.hashCode;
+        return (value.value as Object?).hashCode;
       } else {
         return value.hashCode;
       }

--- a/lib/src/yaml_node.dart
+++ b/lib/src/yaml_node.dart
@@ -152,7 +152,7 @@ class YamlList extends YamlNode with collection.ListMixin {
 /// A wrapped scalar value parsed from YAML.
 class YamlScalar extends YamlNode {
   @override
-  final Object? value;
+  final dynamic value;
 
   /// The style used for the scalar in the original document.
   final ScalarStyle style;


### PR DESCRIPTION
- revert updating the type for YamlScalar.value

This reverts the recent change to specify a specific type for `YamlScalar.value`; this was more breaking than intended (for package:yaml_edit, package:pub, ...).
