### PR TITLE
feat(loader): support merge type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.1.3-wip
 
+* Add support for `merge` type.
+  See https://yaml.org/type/merge.html for examples.
+
 ## 3.1.2
 
 * Require Dart 2.19

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -1899,6 +1899,87 @@ void main() {
         List.generate(keys.length, (i) => i + 1).reduce((n, i) => n * i);
     expect(sanityCheckCount, expectedPermutationCount);
   });
+
+  group('merge', () {
+    test('supports one map', () {
+      expectYamlLoads([
+        {
+          'x': 1,
+          'y': 2,
+        },
+        {
+          'x': 1,
+          'y': 2,
+          'r': 10,
+          'label': 'center/big',
+        },
+      ], '''
+        - &CENTER { x: 1, y: 2 }
+        - # Merge one map
+          << : *CENTER
+          r: 10
+          label: center/big''');
+    });
+
+    test('supports multiple maps', () {
+      expectYamlLoads([
+        {
+          'x': 1,
+          'y': 2,
+        },
+        {
+          'r': 10,
+        },
+        {
+          'x': 1,
+          'y': 2,
+          'r': 10,
+          'label': 'center/big',
+        },
+      ], '''
+        - &CENTER { x: 1, y: 2 }
+        - &BIG { r: 10 }
+        - # Merge multiple maps
+          << : [ *CENTER, *BIG ]
+          label: center/big''');
+    });
+    test('supports override', () {
+      expectYamlLoads([
+        {
+          'x': 0,
+          'y': 2,
+        },
+        {
+          'r': 10,
+        },
+        {
+          'r': 1,
+        },
+        {
+          'x': 1,
+          'y': 2,
+          'r': 10,
+          'label': 'center/big',
+        },
+      ], '''
+        - &LEFT { x: 0, y: 2 }
+        - &BIG { r: 10 }
+        - &SMALL { r: 1 }
+        - # Override
+          << : [ *BIG, *LEFT, *SMALL ]
+          x: 1
+          label: center/big''');
+    });
+    test('duplicate merge throws', () {
+      expectYamlFails('''
+        - &TEST { x: 0 }
+        - &TEST_2 { x: 0 }
+        - << : *TEST
+          << : *TEST_2
+          x: 10
+      ''');
+    });
+  });
 }
 
 Iterable<List<String>> _generatePermutations(List<String> keys) sync* {


### PR DESCRIPTION
Implemented according to https://yaml.org/type/merge.html

Supports:
 - merge single map
 - merge multiple maps
 - correctly overrides

Tests are made for all 3 cases and for duplicate merge key as well.

Closes #121

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

