### PR TITLE
Handle surrogate pairs during scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.3-wip
 
 * Require Dart 3.0
-* Fix UTF-16 surrogate pair handling.
+* Fix UTF-16 surrogate pair handling in plain scaler.
 
 ## 3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.3-wip
 
 * Require Dart 3.0
+* Fix UTF-16 surrogate pair handling.
 
 ## 3.1.2
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -44,52 +44,8 @@ YamlWarningCallback yamlWarningCallback = (message, [SourceSpan? span]) {
   print(message);
 };
 
-// The following utility functions are copied from the string_scanner package.
-//
-// See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF
-// for documentation on how UTF-16 encoding works and definitions of various
-// related terms.
+/// Whether [codeUnit] is a UTF-16 high surrogate.
+bool isHighSurrogate(int codeUnit) => codeUnit >>> 10 == 0x36;
 
-/// The inclusive lower bound of Unicode's supplementary plane.
-const _supplementaryPlaneLowerBound = 0x10000;
-
-/// The inclusive upper bound of Unicode's supplementary plane.
-const _supplementaryPlaneUpperBound = 0x10FFFF;
-
-/// The inclusive lower bound of the UTF-16 high surrogate block.
-const _highSurrogateLowerBound = 0xD800;
-
-/// The inclusive lower bound of the UTF-16 low surrogate block.
-const _lowSurrogateLowerBound = 0xDC00;
-
-/// The number of low bits in each code unit of a surrogate pair that goes into
-/// determining which code point it encodes.
-const _surrogateBits = 10;
-
-/// A bit mask that covers the lower [_surrogateBits] of a code point, which can
-/// be used to extract the value of a surrogate or the low surrogate value of a
-/// code unit.
-const _surrogateValueMask = (1 << _surrogateBits) - 1;
-
-/// Returns whether [codePoint] is in the Unicode supplementary plane, and thus
-/// must be represented as a surrogate pair in UTF-16.
-bool inSupplementaryPlane(int codePoint) =>
-    codePoint >= _supplementaryPlaneLowerBound &&
-    codePoint <= _supplementaryPlaneUpperBound;
-
-/// Returns whether [codeUnit] is a UTF-16 high surrogate.
-bool isHighSurrogate(int codeUnit) =>
-    (codeUnit & ~_surrogateValueMask) == _highSurrogateLowerBound;
-
-/// Returns whether [codeUnit] is a UTF-16 low surrogate.
-bool isLowSurrogate(int codeUnit) =>
-    (codeUnit >> _surrogateBits) == (_lowSurrogateLowerBound >> _surrogateBits);
-
-/// Converts a UTF-16 surrogate pair into the Unicode code unit it represents.
-int decodeSurrogatePair(int highSurrogate, int lowSurrogate) {
-  assert(isHighSurrogate(highSurrogate));
-  assert(isLowSurrogate(lowSurrogate));
-  return _supplementaryPlaneLowerBound +
-      (((highSurrogate & _surrogateValueMask) << _surrogateBits) |
-          (lowSurrogate & _surrogateValueMask));
-}
+/// Whether [codeUnit] is a UTF-16 low surrogate.
+bool isLowSurrogate(int codeUnit) => codeUnit >>> 10 == 0x37;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -43,3 +43,53 @@ YamlWarningCallback yamlWarningCallback = (message, [SourceSpan? span]) {
   if (span != null) message = span.message(message);
   print(message);
 };
+
+// The following utility functions are copied from the string_scanner package.
+//
+// See https://en.wikipedia.org/wiki/UTF-16#Code_points_from_U+010000_to_U+10FFFF
+// for documentation on how UTF-16 encoding works and definitions of various
+// related terms.
+
+/// The inclusive lower bound of Unicode's supplementary plane.
+const _supplementaryPlaneLowerBound = 0x10000;
+
+/// The inclusive upper bound of Unicode's supplementary plane.
+const _supplementaryPlaneUpperBound = 0x10FFFF;
+
+/// The inclusive lower bound of the UTF-16 high surrogate block.
+const _highSurrogateLowerBound = 0xD800;
+
+/// The inclusive lower bound of the UTF-16 low surrogate block.
+const _lowSurrogateLowerBound = 0xDC00;
+
+/// The number of low bits in each code unit of a surrogate pair that goes into
+/// determining which code point it encodes.
+const _surrogateBits = 10;
+
+/// A bit mask that covers the lower [_surrogateBits] of a code point, which can
+/// be used to extract the value of a surrogate or the low surrogate value of a
+/// code unit.
+const _surrogateValueMask = (1 << _surrogateBits) - 1;
+
+/// Returns whether [codePoint] is in the Unicode supplementary plane, and thus
+/// must be represented as a surrogate pair in UTF-16.
+bool inSupplementaryPlane(int codePoint) =>
+    codePoint >= _supplementaryPlaneLowerBound &&
+    codePoint <= _supplementaryPlaneUpperBound;
+
+/// Returns whether [codeUnit] is a UTF-16 high surrogate.
+bool isHighSurrogate(int codeUnit) =>
+    (codeUnit & ~_surrogateValueMask) == _highSurrogateLowerBound;
+
+/// Returns whether [codeUnit] is a UTF-16 low surrogate.
+bool isLowSurrogate(int codeUnit) =>
+    (codeUnit >> _surrogateBits) == (_lowSurrogateLowerBound >> _surrogateBits);
+
+/// Converts a UTF-16 surrogate pair into the Unicode code unit it represents.
+int decodeSurrogatePair(int highSurrogate, int lowSurrogate) {
+  assert(isHighSurrogate(highSurrogate));
+  assert(isLowSurrogate(lowSurrogate));
+  return _supplementaryPlaneLowerBound +
+      (((highSurrogate & _surrogateValueMask) << _surrogateBits) |
+          (lowSurrogate & _surrogateValueMask));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   source_span: ^1.8.0
-  string_scanner: ^1.1.0
+  string_scanner: ^1.2.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -420,7 +420,7 @@ void main() {
 
     test('[Example 2.17]', () {
       expectYamlLoads({
-        'unicode': 'Sosa did fine.\u263A',
+        'unicode': 'Sosa did fine.\u263A \u{1F680}',
         'control': '\b1998\t1999\t2000\n',
         'hex esc': '\r\n is \r\n',
         'single': '"Howdy!" he cried.',
@@ -429,7 +429,7 @@ void main() {
         'surrogate-pair': 'I \u{D83D}\u{DE03}  ️Dart!',
         'key-\u{D83D}\u{DD11}': 'Look\u{D83D}\u{DE03}\u{D83C}\u{DF89}surprise!',
       }, """
-        unicode: "Sosa did fine.\\u263A"
+        unicode: "Sosa did fine.\\u263A \\U0001F680"
         control: "\\b1998\\t1999\\t2000\\n"
         hex esc: "\\x0d\\x0a is \\r\\n"
 

--- a/test/yaml_test.dart
+++ b/test/yaml_test.dart
@@ -425,7 +425,9 @@ void main() {
         'hex esc': '\r\n is \r\n',
         'single': '"Howdy!" he cried.',
         'quoted': " # Not a 'comment'.",
-        'tie-fighter': '|\\-*-/|'
+        'tie-fighter': '|\\-*-/|',
+        'surrogate-pair': 'I \u{D83D}\u{DE03}  ️Dart!',
+        'key-\u{D83D}\u{DD11}': 'Look\u{D83D}\u{DE03}\u{D83C}\u{DF89}surprise!',
       }, """
         unicode: "Sosa did fine.\\u263A"
         control: "\\b1998\\t1999\\t2000\\n"
@@ -433,7 +435,10 @@ void main() {
 
         single: '"Howdy!" he cried.'
         quoted: ' # Not a ''comment''.'
-        tie-fighter: '|\\-*-/|'""");
+        tie-fighter: '|\\-*-/|'
+        
+        surrogate-pair: I \u{D83D}\u{DE03}  ️Dart!
+        key-\u{D83D}\u{DD11}: Look\u{D83D}\u{DE03}\u{D83C}\u{DF89}surprise!""");
     });
 
     test('[Example 2.18]', () {


### PR DESCRIPTION
Fixes #53.

## The problem

Issue #53 is about adding support to Emoji characters, and the root cause of this issue is that the current YAML package doesn't handle surrogate pairs when parsing.

## Why?

In the [YAML spec](https://yaml.org/spec/1.2-old/spec.html#id2770814), a *character* is a Unicode code point (quote *Section 5.2: "All characters mentioned in this specification are Unicode code points. Each such code point is written as one or more bytes depending on the character encoding used. Note that in UTF-16, characters above #xFFFF are written as four bytes, using a surrogate pair."*). And in Section 5.1, the spec defines a list of acceptable Unicode *characters*, with UTF-16 surrogates explicitly excluded.

On the other hand, this package utilizes the `string_scanner` package to do string parsing or scanning, especially its `peekChar()` and `readChar()` methods. And the consumed "*character*" (in `int`) will be passed to the `_isStandardCharacter()` method in `scanner.dart` to test whether this Unicode *character* is an allowed one:

https://github.com/dart-lang/yaml/blob/e5984433a2803d5c67ed0abac5891a55040381ee/lib/src/scanner.dart#L1594-L1598

The problem is that a *character* (or char) returned by `peekChar()` or `readChar()` in `string_scanner` is actually a "code unit", and the "*character*" expected by `_isStandardCharacter()` is a "code point". As a result, `peekChar()` and `readChar()` can return a surrogate (usually the higher one) that represents a paired code units, and the value will be immediately rejected by `_isStandardCharacter()`.

The impact is that the package will reject all code points that requires a surrogate pairs if the string is not quoted. This doesn't only affect Emojis.

## A note on my previous attempt

I had submitted a pull request at https://github.com/dart-lang/string_scanner/pull/69, hoping that it can ease fixing the issue of the yaml package. But later I feel increasing uncomfortable about changing a codepoint-centric method to accept an `offset` argument that act upon code units. So I asked to make that pull request on hold, and decided to present my idea here for feedback first.

## What is in this pull request

This pull request doesn’t need any modifications to the `string_scanner` package as I’ve copied the required utility functions from it. Basically, I’ve implemented the following changes:

1. I have replaced all instances of `_scanner.readChar()` with `_scanner.readCodePoint()`. Although `_scanner.readChar()` could still be used in some areas, I’ve chosen to maintain consistency to prevent potential confusion or unintentional bugs in the future.
2. Instances that invoke `_isStandardCharacter()` have been modified to call the new method `_isStandardCharacterAt()`. This new method is responsible for checking and merging surrogate pairs, and then passing the actual codepoint/character to _isStandardCharacter().

## Misc.

benchmark.dart output before and after the fix (in JIT mode):

#### Before
```
Run #1: 0.124ms ============
Run #3: 0.116ms ===========
Run #4: 0.111ms ===========
Run #5: 0.110ms ===========
Run #8: 0.107ms ==========
Run #9: 0.106ms ==========
Run #10: 0.105ms ==========
Run #11: 0.099ms =========
Run #12: 0.092ms =========
Run #15: 0.091ms =========
Run #17: 0.089ms ========
Run #23: 0.077ms =======
Run #29: 0.065ms ======
Run #30: 0.064ms ======
Run #32: 0.059ms =====
Run #34: 0.057ms =====
Run #40: 0.056ms =====
Best   : 0.056ms =====
```

#### After
```
Run #1: 0.110ms ===========
Run #3: 0.100ms ==========
Run #5: 0.090ms =========
Run #9: 0.082ms ========
Run #10: 0.072ms =======
Run #11: 0.070ms =======
Run #12: 0.064ms ======
Run #14: 0.062ms ======
Run #18: 0.061ms ======
Run #21: 0.059ms =====
Best   : 0.059ms =====
```
